### PR TITLE
docs(secrets): clarify strict-mode scope and instance-level llm.apiKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .site/
 node_modules/
 .DS_Store
+.codex/config.toml

--- a/docs/reference/deploy/environment-variables.md
+++ b/docs/reference/deploy/environment-variables.md
@@ -55,7 +55,7 @@ Related deployment variables:
 |---|---|
 | `PAPERCLIP_SECRETS_MASTER_KEY` | 32-byte encryption key as base64, hex, or raw |
 | `PAPERCLIP_SECRETS_MASTER_KEY_FILE` | Path to the local key file |
-| `PAPERCLIP_SECRETS_STRICT_MODE` | Require secret refs for sensitive env vars |
+| `PAPERCLIP_SECRETS_STRICT_MODE` | Require secret refs for server-side env bindings. Does not apply to `paperclipai configure --section llm` or `config.llm.apiKey`. |
 
 These values are covered in more detail in [Secrets](./secrets.md).
 

--- a/docs/reference/deploy/secrets.md
+++ b/docs/reference/deploy/secrets.md
@@ -50,7 +50,7 @@ pnpm paperclipai doctor
 |---|---|
 | `PAPERCLIP_SECRETS_MASTER_KEY` | 32-byte key as base64, hex, or raw string |
 | `PAPERCLIP_SECRETS_MASTER_KEY_FILE` | Custom path to the local key file |
-| `PAPERCLIP_SECRETS_STRICT_MODE` | Require secret refs for sensitive env vars |
+| `PAPERCLIP_SECRETS_STRICT_MODE` | Require secret refs for server-side env bindings. Does not apply to `paperclipai configure --section llm` or `config.llm.apiKey`. |
 
 Enable strict mode with:
 
@@ -64,11 +64,28 @@ Use strict mode when you want to prevent new inline sensitive values from enteri
 
 ## Strict Mode
 
-When strict mode is on, sensitive env keys such as `*_API_KEY`, `*_TOKEN`, and `*_SECRET` must use secret references instead of inline plaintext.
+Strict mode is server-side enforcement for persisted environment bindings. When it is on, sensitive env keys such as `*_API_KEY`, `*_TOKEN`, and `*_SECRET` must use secret references; inline plaintext values are rejected.
+
+It applies when the server persists:
+
+- agent `adapterConfig.env`
+- project `env`
+- hire-agent approval payloads that carry adapter env
+- company imports that carry agent adapter env
 
 This is the safer choice for anything beyond a local trusted install.
 
+Strict mode does **not** apply to `paperclipai configure --section llm`. That command writes plaintext to `config.llm.apiKey` regardless of `PAPERCLIP_SECRETS_STRICT_MODE`.
+
 > **Warning:** Strict mode blocks new inline sensitive values. It does not automatically migrate what is already stored.
+
+---
+
+## Secrets At The Instance Level
+
+`config.llm.apiKey` is a plain string field. It does not support `secret_ref` today, and there is no CLI or API path that stores the instance-level key in the secret store.
+
+For end-to-end secret-ref hygiene, leave `config.llm.apiKey` empty and bind each agent adapter API key in `adapterConfig.env` using `secret_ref` as shown below.
 
 ---
 
@@ -82,6 +99,10 @@ pnpm secrets:migrate-inline-env --apply
 ```
 
 Run the command without `--apply` first if you want a dry run.
+
+> **Note:** `pnpm secrets:migrate-inline-env` is a repository-source script. It is available only from a Paperclip git checkout, not from an installed `paperclipai` CLI.
+
+The script only scans `agent.adapterConfig.env` keys matching a sensitive-keyword regex (for example `api_key`, `token`, `secret`, `password`, `credential`). It does not migrate `config.llm.apiKey`.
 
 ---
 


### PR DESCRIPTION
## Summary

Originated from a community thread where a user enabled `PAPERCLIP_SECRETS_STRICT_MODE=true` and was surprised that `paperclipai configure --section llm` still wrote a plaintext API key to `config.llm.apiKey`. The docs implied strict mode was global; it isn't.

This PR is documentation-only. No code or schema changes.

- **`docs/reference/deploy/secrets.md`**
  - Strict Mode section now states it is server-side enforcement for persisted env bindings, and enumerates the four enforcement points: agent `adapterConfig.env`, project `env`, hire-agent approval payloads, company imports.
  - Adds explicit note that strict mode does not apply to `paperclipai configure --section llm`.
  - New **Secrets At The Instance Level** section: `config.llm.apiKey` is plain string only, no `secret_ref` support; recommended pattern is to leave it empty and bind keys per-agent in `adapterConfig.env`.
  - Migrate Inline Secrets section flags `pnpm secrets:migrate-inline-env` as a repository-source script (not exposed by the installed `paperclipai` CLI) and notes its scope is `agent.adapterConfig.env` only — it does not migrate `config.llm.apiKey`.
- **`docs/reference/deploy/environment-variables.md`** — strict-mode row updated to match the new wording so the two pages don't contradict.
- **`.gitignore`** — ignore local `.codex/config.toml` tooling.

## Test plan

- [ ] Render the two docs pages and confirm the new sections read cleanly.
- [ ] Confirm the strict-mode wording matches between `secrets.md` and `environment-variables.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)