### PR TITLE
Fill plugin coverage gaps (llm-wiki, orchestration-smoke, fake-sandbox)

### DIFF
--- a/docs/administration/plugins.md
+++ b/docs/administration/plugins.md
@@ -66,6 +66,7 @@ The examples that ship today:
 - **plugin-file-browser-example** — adds a Files link to project sidebars and a file-browser tab to the project detail page, scoped to the project's workspace.
 - **plugin-kitchen-sink-example** — demonstrates the full plugin surface in one package: pages, widgets, settings forms, scheduled jobs, webhooks. Good for exploring what a plugin can do.
 - **plugin-authoring-smoke-example** — a thin smoke test for the plugin authoring workflow. Useful if you're working on a plugin of your own and want to confirm the runtime picks it up.
+- **plugin-orchestration-smoke-example** — a smoke plugin that exercises Paperclip's orchestration-grade plugin APIs (scheduled jobs, webhooks, plugin-driven agent interactions). Useful as a reference when you're building a plugin that needs to coordinate work over time, not just render a widget.
 
 **By npm package name.** Click the **Install Plugin** button at the top right of the Plugin Manager. Paperclip asks for an npm package name (for example, `@paperclipai/plugin-example`). Submit it and Paperclip fetches, installs, and loads the package. Success or failure appears as a toast, and the plugin shows up in the installed list with its current status.
 

--- a/docs/administration/plugins.md
+++ b/docs/administration/plugins.md
@@ -58,7 +58,9 @@ An errored plugin stays installed — you don't need to uninstall and reinstall 
 
 There are two ways to get a plugin into Paperclip.
 
-**From the Available Plugins list.** Bundled example plugins ship inside the Paperclip repository. On the Plugin Manager page, scroll to the **Available Plugins** section and click **Install Example** next to the one you want. Paperclip installs it straight from the local checkout — no registry round trip.
+**From the Available Plugins list.** Bundled example plugins ship inside the Paperclip repository. On the Plugin Manager page, scroll to the **Available Plugins** section and click **Install Example** next to the one you want. Paperclip installs it straight from the local checkout — no registry round trip. The same list is what `paperclipai plugin examples` returns from the CLI.
+
+> The Available Plugins list is intentionally just the **reference examples** below — it's not the full catalogue of first-party plugins. Real first-party plugins like the [LLM Wiki](../reference/plugins/llm-wiki.md) are published to npm and installed by full package name; see *By npm package name* below.
 
 The examples that ship today:
 

--- a/docs/reference/adapters/sandbox-providers.md
+++ b/docs/reference/adapters/sandbox-providers.md
@@ -62,6 +62,16 @@ Configure from **Company Settings → Environments**. The plugin manifest declar
 
 ---
 
+## Fake Sandbox (`provider: "fake-plugin"`)
+
+Package: `@paperclipai/plugin-fake-sandbox`.
+
+A first-party deterministic sandbox provider that runs commands in an isolated local temp directory while exercising the full sandbox-provider plugin lifecycle. It's intended for development, integration testing, and reproducing plugin-runtime issues without an external sandbox service.
+
+The plugin is private to the monorepo (`"private": true` in its `package.json`), so it isn't published to npm — you build and install it locally as a workspace plugin. The `configSchema` exposes `image` (a deterministic fake label, default `fake:latest`), `timeoutMs` (default `300000`), and `reuseLease`. Pick this provider when you want predictable sandbox behavior in tests, or when you're debugging the provider-plugin contract itself.
+
+---
+
 ## Related
 
 - [Plugins](../../administration/plugins.md) — install and manage plugins from the Plugin Manager.

--- a/docs/reference/plugins/llm-wiki.md
+++ b/docs/reference/plugins/llm-wiki.md
@@ -6,9 +6,27 @@ paperclip_version: v2026.512.0
 
 If you want a cited, in-dashboard wiki that your agents build and maintain from raw source material — Paperclip issues, comments, documents, and files you drop into a folder — the `@paperclipai/plugin-llm-wiki` plugin is the surface that does it. It captures sources into a local folder, lets agents ingest them into markdown pages with backlinks and provenance, and ships a Wiki page inside Paperclip so you (and the agents) can browse the result.
 
-This page is for **operators** who want to enable and configure the plugin. The mechanics of *how* plugins are installed and authored live elsewhere — see [Administration → Plugins](../../administration/plugins.md) and [How-to → Develop a plugin locally](../../how-to/develop-a-plugin-locally.md). This page covers what the plugin contributes once it's running.
+This page is for **operators** who want to enable and configure the plugin.
 
 > The LLM Wiki plugin is in alpha alongside the plugin runtime itself. Expect breaking changes between Paperclip releases and pin your version when you depend on it.
+
+---
+
+## Quick install
+
+The plugin ships as a published npm package, so any Paperclip install (Docker, systemd, bare-metal — all the same) can pull it in with one command from a host that has your Paperclip CLI configured:
+
+```sh
+paperclipai plugin install @paperclipai/plugin-llm-wiki
+```
+
+Or from the dashboard: **Settings → Plugins → Install Plugin**, paste `@paperclipai/plugin-llm-wiki`, submit.
+
+The plugin won't appear in `paperclipai plugin examples` — that command only lists the four built-in reference *example* plugins, not the full catalogue of first-party plugins. Install LLM Wiki by full package name.
+
+If you're running from a monorepo checkout, see [Develop a plugin locally](../../how-to/develop-a-plugin-locally.md) and point the installer at `packages/plugins/plugin-llm-wiki` instead.
+
+The first enable asks for a fairly broad capability set — including `local.folders`, the `database.namespace.*` family, `agents.managed`, `skills.managed`, `routines.managed`, and `ui.page.register` — because the plugin owns a managed agent, project, routines, skills, REST routes, and a database namespace. Review the Permissions card on the plugin detail page before approving.
 
 ---
 
@@ -28,16 +46,6 @@ Behind the scenes the plugin also registers:
 - A bundle of managed skills installed for the maintainer agent: `wiki-maintainer`, `wiki-ingest`, `wiki-query`, `wiki-lint`, `paperclip-distill`, and `index-refresh`.
 
 The routines ship paused so nothing fires until you decide it should. Enable them from the plugin's settings or from the standard managed-routines surface.
-
----
-
-## Installing it
-
-The plugin installs through the standard plugin flow — the Plugin Manager under **Settings → Plugins**. The mechanics (Install Plugin button, npm vs local path, status transitions, capability approval) are the same as any other plugin; see [Administration → Plugins](../../administration/plugins.md) for the full walkthrough.
-
-If you're developing or running it from a checkout, follow [Develop a plugin locally](../../how-to/develop-a-plugin-locally.md) and point the installer at `packages/plugins/plugin-llm-wiki`. The package name is `@paperclipai/plugin-llm-wiki`.
-
-The first time you enable the plugin it asks for a fairly broad capability set — including `local.folders`, the `database.namespace.*` family, `agents.managed`, `skills.managed`, `routines.managed`, and `ui.page.register` — because it owns a managed agent, project, routines, skills, REST routes, and a database namespace. Review the Permissions card on the plugin detail page before approving.
 
 ---
 

--- a/docs/reference/plugins/llm-wiki.md
+++ b/docs/reference/plugins/llm-wiki.md
@@ -1,0 +1,147 @@
+---
+paperclip_version: v2026.512.0
+---
+
+# LLM Wiki
+
+If you want a cited, in-dashboard wiki that your agents build and maintain from raw source material — Paperclip issues, comments, documents, and files you drop into a folder — the `@paperclipai/plugin-llm-wiki` plugin is the surface that does it. It captures sources into a local folder, lets agents ingest them into markdown pages with backlinks and provenance, and ships a Wiki page inside Paperclip so you (and the agents) can browse the result.
+
+This page is for **operators** who want to enable and configure the plugin. The mechanics of *how* plugins are installed and authored live elsewhere — see [Administration → Plugins](../../administration/plugins.md) and [How-to → Develop a plugin locally](../../how-to/develop-a-plugin-locally.md). This page covers what the plugin contributes once it's running.
+
+> The LLM Wiki plugin is in alpha alongside the plugin runtime itself. Expect breaking changes between Paperclip releases and pin your version when you depend on it.
+
+---
+
+## What you get
+
+Once the plugin is installed and enabled, three things show up in the Paperclip UI:
+
+- **A Wiki sidebar entry** (slot id `wiki-sidebar`, order `35`) that takes you to the plugin page.
+- **A Wiki page** mounted at the `wiki` route inside the plugin's company-scoped namespace (slot id `wiki-page`). This is where you browse pages, capture sources, kick off query sessions, and inspect operations.
+- **A Wiki route sidebar** (slot id `wiki-route-sidebar`) for navigating between spaces and pages while you're inside the wiki.
+
+Behind the scenes the plugin also registers:
+
+- A managed agent — the **Wiki Maintainer** (`agentKey: wiki-maintainer`, role `knowledge-maintainer`) — that owns ingest, query, lint, and index work.
+- A managed project — **LLM Wiki** (`projectKey: llm-wiki`) — that collects the plugin's operation issues.
+- Three managed routines, all paused by default: `cursor-window-processing` (process Paperclip issue-history windows), `nightly-wiki-lint` (audit pages for orphans, stale provenance, and contradictions), and `index-refresh` (rebuild `wiki/index.md`).
+- A bundle of managed skills installed for the maintainer agent: `wiki-maintainer`, `wiki-ingest`, `wiki-query`, `wiki-lint`, `paperclip-distill`, and `index-refresh`.
+
+The routines ship paused so nothing fires until you decide it should. Enable them from the plugin's settings or from the standard managed-routines surface.
+
+---
+
+## Installing it
+
+The plugin installs through the standard plugin flow — the Plugin Manager under **Settings → Plugins**. The mechanics (Install Plugin button, npm vs local path, status transitions, capability approval) are the same as any other plugin; see [Administration → Plugins](../../administration/plugins.md) for the full walkthrough.
+
+If you're developing or running it from a checkout, follow [Develop a plugin locally](../../how-to/develop-a-plugin-locally.md) and point the installer at `packages/plugins/plugin-llm-wiki`. The package name is `@paperclipai/plugin-llm-wiki`.
+
+The first time you enable the plugin it asks for a fairly broad capability set — including `local.folders`, the `database.namespace.*` family, `agents.managed`, `skills.managed`, `routines.managed`, and `ui.page.register` — because it owns a managed agent, project, routines, skills, REST routes, and a database namespace. Review the Permissions card on the plugin detail page before approving.
+
+---
+
+## The wiki root folder
+
+The plugin declares one local folder mount — the **Wiki root** (`folderKey: wiki-root`, `access: readWrite`). Everything the wiki produces or reads lives there.
+
+When you bootstrap the folder (via the plugin's settings page, or the `bootstrap` / `bootstrap-space` API routes), the plugin creates the following layout:
+
+```text
+<wiki-root>/
+  AGENTS.md
+  IDEA.md
+  wiki/
+    index.md
+    log.md
+    sources/
+    projects/
+    entities/
+    concepts/
+    synthesis/
+  raw/
+```
+
+`AGENTS.md` and `IDEA.md` are control files — they hold the maintainer agent's instructions and the company's stated direction. They're protected: agent tool writes can't overwrite them, only operator edits can. `wiki/log.md` is the rolling audit trail every routine appends to. `raw/` holds captured source material before it becomes a durable page.
+
+Bootstrap preserves existing files rather than overwriting them, so it's safe to re-run after you've started editing.
+
+---
+
+## Spaces
+
+A single wiki root can host multiple **spaces** — independent wiki bodies under one configured folder. The plugin always provisions a `default` space (slug: `default`) and lets you create more via the `POST /spaces` route or the settings UI. Each space gets its own `wiki/`, `raw/`, page index, and operation history.
+
+One thing to know up front: **Paperclip-derived ingestion always writes into the `default` space.** The cursor-window, distill, and backfill flows are not yet space-aware, so non-default spaces stay on manual or raw-file ingest for now. Per-space Paperclip ingestion profiles are tracked as a later phase.
+
+---
+
+## Capturing sources and building pages
+
+The plugin offers two paths from raw material to a wiki page:
+
+**Manual capture.** Drop files into `<wiki-root>/raw/` (or call the `POST /sources` route — `routeKey: capture-source`) to register them as a captured source with metadata in the plugin's database namespace. From there an agent — typically the Wiki Maintainer running the `wiki-ingest` skill — turns the raw source into a cited markdown page under `wiki/concepts/`, `wiki/entities/`, `wiki/synthesis/`, or a project folder.
+
+**Paperclip event ingestion.** Opt in to company-scoped ingestion of Paperclip issues, comments, and documents. It is **disabled by default**. When you enable it, the plugin's worker watches host events, captures eligible content into the default space's `raw/`, and lets the maintainer agent distill it into project pages. The defaults cap per-source size at 12,000 characters for issues, 60,000 for cursor windows, and 120,000 for routine runs.
+
+Pages are plain markdown on disk. The plugin indexes them in its database namespace (`namespaceSlug: llm_wiki`) for search, backlinks, and revision history, and uses Paperclip's local-folder API for path containment, symlink checks, and atomic writes. Two files are reserved: `AGENTS.md` and `IDEA.md` cannot be written through agent tools.
+
+---
+
+## Tools agents can call
+
+When the maintainer agent (or any agent you grant `pluginTools: [paperclipai.plugin-llm-wiki]`) runs, the plugin exposes a focused tool surface for working with the wiki:
+
+| Tool | What it does |
+|---|---|
+| `wiki_search` | Full-text search across page and source metadata in one space. |
+| `wiki_list_pages` | Return the indexed page list for a space. |
+| `wiki_read_page` | Read a markdown page. |
+| `wiki_write_page` | Atomic page write, with optional `expectedHash` for stale-write protection. |
+| `wiki_propose_patch` | Return a structured proposed write without changing files — useful for review flows. |
+| `wiki_list_sources` / `wiki_read_source` | Inspect captured raw material before citing it. |
+| `wiki_list_backlinks` | Find pages that link to a given page. |
+| `wiki_update_index` | Atomically replace `wiki/index.md`. |
+| `wiki_append_log` | Append a maintenance note to `wiki/log.md`. |
+
+Each tool takes `companyId`, `wikiId`, and (optionally) `spaceSlug`. Operation agents should pass the issue's `spaceSlug`; omitting it falls back to the `default` space.
+
+---
+
+## REST routes
+
+The plugin mounts these routes under its plugin namespace (auth column shows which actor can hit each one):
+
+| Method & path | Route key | Auth |
+|---|---|---|
+| `GET /overview` | `overview` | board-or-agent |
+| `POST /bootstrap` | `bootstrap` | board |
+| `POST /sources` | `capture-source` | board-or-agent |
+| `GET /spaces` | `spaces` | board-or-agent |
+| `POST /spaces` | `create-space` | board |
+| `PATCH /spaces/:spaceSlug` | `update-space` | board |
+| `POST /spaces/:spaceSlug/bootstrap` | `bootstrap-space` | board |
+| `POST /spaces/:spaceSlug/archive` | `archive-space` | board |
+| `GET /operations` | `operations` | board-or-agent |
+| `POST /query-sessions` | `start-query` | board |
+| `POST /file-as-page` | `file-as-page` | board |
+
+`board`-auth routes are operator actions; `board-or-agent` routes are safe for the maintainer agent to call as part of a routine.
+
+---
+
+## Tips and common use cases
+
+- **Start with one space.** The default space is enough to evaluate the plugin. Add spaces only when you have a separate body of knowledge that should not co-mingle with the rest.
+- **Keep the routines paused until you have a wiki root configured.** The maintainer agent will create operation issues, but its tools will refuse writes until the folder bootstrap is complete.
+- **Edit `IDEA.md` yourself.** It's the place the maintainer reads to understand the company's direction; treat it as an operator-curated document, not an agent-managed one.
+- **Use `wiki_propose_patch` for review flows.** If you want operator-in-the-loop edits, route the maintainer through proposed patches instead of direct writes and approve them via the operation issue.
+- **Watch `wiki/log.md`.** Every routine appends a short entry there — orphan counts, source windows processed, index refresh times. It's the fastest way to see what the maintainer has been up to.
+
+---
+
+## Related
+
+- [Administration → Plugins](../../administration/plugins.md) — the operator-facing Plugin Manager.
+- [How-to → Develop a plugin locally](../../how-to/develop-a-plugin-locally.md) — point Paperclip at a local checkout of the plugin.
+- [Reference → Plugin SDK](./sdk.md) — the authoring surface, if you want to extend the wiki plugin or write your own.

--- a/site/content.json
+++ b/site/content.json
@@ -421,6 +421,10 @@
         {
           "title": "Plugin SDK",
           "file": "../docs/reference/plugins/sdk.md"
+        },
+        {
+          "title": "LLM Wiki",
+          "file": "../docs/reference/plugins/llm-wiki.md"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Backfills documentation for three first-party plugins surfaced as gaps during the v2026.513.0 release run. All three predate the `/sync-docs` skill's tracking window (they shipped in or before `v2026.512.0`) and slipped through the prior batched catchup.

## What's added

- **NEW** `docs/reference/plugins/llm-wiki.md` — full reference page for the **LLM Wiki** plugin (`@paperclipai/plugin-llm-wiki`, introduced in `v2026.512.0` via [#5716](https://github.com/paperclipai/paperclip/pull/5716)). Covers the dashboard UI surface (`wiki-sidebar`, `wiki-page`, `wiki-route-sidebar`), the managed `wiki-maintainer` agent, the `llm-wiki` project, paused routines, the `wiki-root` local folder, the `llm_wiki` database namespace, the ten `wiki_*` tools, and all REST routes (`overview`, `bootstrap`, `capture-source`, `spaces`, etc.).
- **`docs/administration/plugins.md`** — adds the missing `plugin-orchestration-smoke-example` bullet alongside the four examples that were already documented.
- **`docs/reference/adapters/sandbox-providers.md`** — new "Fake Sandbox" section for `@paperclipai/plugin-fake-sandbox` (`provider: "fake-plugin"`), the private deterministic sandbox provider used for plugin-runtime testing.
- **`site/content.json`** — nav entry for the new LLM Wiki page under `Reference / Plugins`.

## Why this isn't in PR #6

PR #6 documented the `v2026.512.0 → v2026.513.0` diff window. These three gaps fall *inside* `v2026.512.0` (or earlier), so they were never visible to the cumulative diff. Surfacing them required an explicit audit of `packages/plugins/**` at `v2026.513.0` against our docs, which sits outside the standard sync flow.

## Audit method (for future reference)

Compared `gh api repos/paperclipai/paperclip/contents/packages/plugins/...?ref=v2026.513.0` against `grep -rln <plugin-name> docs/`. Plugins inventoried:

| Plugin | Already documented |
|---|---|
| `create-paperclip-plugin` | ✅ |
| `examples/plugin-hello-world-example` | ✅ |
| `examples/plugin-file-browser-example` | ✅ |
| `examples/plugin-kitchen-sink-example` | ✅ |
| `examples/plugin-authoring-smoke-example` | ✅ |
| `examples/plugin-orchestration-smoke-example` | ❌ → added |
| `paperclip-plugin-fake-sandbox` | ❌ → added |
| `plugin-llm-wiki` | ❌ → added |
| `sandbox-providers/cloudflare` | ✅ |
| `sandbox-providers/daytona` | ✅ |
| `sandbox-providers/e2b` | ✅ |
| `sandbox-providers/exe-dev` | ✅ |
| `sdk` | ✅ |

## Build / checks

- `docs:build` passes.
- `sync:check`: 3 pre-existing broken screenshot links (tracked in `maintenance/follow-ups.md`), 1 pre-existing orphan. No new issues.
- `verify-edit.mjs` on `llm-wiki.md`: 0 unverified, 0 suspicious.

## Reviewer checklist

- [ ] Voice/tone on the new `llm-wiki.md` page.
- [ ] Confirm the Fake Sandbox section in `sandbox-providers.md` is the right framing (test-only vs. general-purpose). The package is `private: true` upstream, so the doc leans on the "for testing / reproducing plugin-runtime issues" angle.
- [ ] Consider whether `paperclip-plugin-fake-sandbox` should be excluded from public docs entirely if it's strictly internal.

## Drift / verification

None. This PR addresses the inverse problem (things we should document but don't), which the standard drift check can't surface — that one looks for documented surfaces that have vanished, not undocumented surfaces that exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)