### PR TITLE
Implement persistent docs On this page sidebar

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -27,6 +27,10 @@ let allPages    = [];
 let currentFile = null;
 let currentMarkdown = '';
 let tocObserver = null;
+let tocScrollHandler = null;
+let tocResizeHandler = null;
+let tocDocumentClickHandler = null;
+let tocKeydownHandler = null;
 const APP_DIR_NAME = 'site';
 const APP_BASE_PATH = (() => {
   const marker = `/${APP_DIR_NAME}`;
@@ -1263,15 +1267,49 @@ function postProcessInternalLinks(root) {
   });
 }
 
-/* ─── Table of contents (pill toggle + floating dropdown) ───────────────── */
+/* ─── Table of contents (desktop rail + compact dropdown) ───────────────── */
+function resetToc() {
+  if (tocObserver) {
+    tocObserver.disconnect();
+    tocObserver = null;
+  }
+  if (tocScrollHandler) {
+    window.removeEventListener('scroll', tocScrollHandler);
+    tocScrollHandler = null;
+  }
+  if (tocResizeHandler) {
+    window.removeEventListener('resize', tocResizeHandler);
+    tocResizeHandler = null;
+  }
+  if (tocDocumentClickHandler) {
+    document.removeEventListener('click', tocDocumentClickHandler);
+    tocDocumentClickHandler = null;
+  }
+  if (tocKeydownHandler) {
+    document.removeEventListener('keydown', tocKeydownHandler);
+    tocKeydownHandler = null;
+  }
+
+  document.querySelectorAll('.toc-wrap').forEach(el => el.remove());
+  const rail = document.getElementById('toc-rail');
+  const railLinks = document.getElementById('toc-rail-links');
+  if (railLinks) railLinks.innerHTML = '';
+  if (rail) rail.classList.add('is-empty');
+}
+
+function headingLabel(heading) {
+  const clone = heading.cloneNode(true);
+  clone.querySelectorAll('.heading-anchor').forEach(anchor => anchor.remove());
+  return clone.textContent.trim();
+}
+
 function buildToc(article, file) {
-  if (tocObserver) { tocObserver.disconnect(); tocObserver = null; }
+  resetToc();
 
   const metaRow = article.querySelector('.meta-row');
-  if (!metaRow) return;
-
-  // Clear previous (defensive)
-  metaRow.querySelector('.toc-wrap')?.remove();
+  const rail = document.getElementById('toc-rail');
+  const railLinks = document.getElementById('toc-rail-links');
+  if (!metaRow || !rail || !railLinks) return;
 
   const headings = [...article.querySelectorAll('h2, h3')];
   if (headings.length < 2) return;
@@ -1280,6 +1318,21 @@ function buildToc(article, file) {
 
   const CHEVRON_SVG = '<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="m3 4.5 3 3 3-3"/></svg>';
   const TOC_SVG = '<svg class="toc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h10M3 8h7M3 12h9"/></svg>';
+
+  function makeTocLink(heading, onClick) {
+    const a = document.createElement('a');
+    a.className = `toc-link ${heading.tagName === 'H3' ? 'level-3' : 'level-2'}`;
+    a.dataset.headingId = heading.id;
+    a.textContent = headingLabel(heading);
+    a.href = page ? getPageHeadingUrl(page, heading.id) : `#${heading.id}`;
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      if (page) history.pushState(null, '', getPageHeadingUrl(page, heading.id));
+      focusHeading(heading);
+      if (onClick) onClick();
+    });
+    return a;
+  }
 
   const wrap = document.createElement('div');
   wrap.className = 'toc-wrap';
@@ -1300,46 +1353,64 @@ function buildToc(article, file) {
   const openPanel = () => { panel.classList.add('is-open'); toggle.setAttribute('aria-expanded', 'true'); };
 
   headings.forEach(h => {
-    const a = document.createElement('a');
-    a.className = `toc-link ${h.tagName === 'H3' ? 'level-3' : 'level-2'}`;
-    a.dataset.headingId = h.id;
-    // Use textContent minus the trailing heading-anchor (the anchor was appended after text, so textContent
-    // after decorateHeadings still has the svg text — but textContent on an <a> with svg is empty. Safe to use h.textContent which
-    // includes only text nodes and keyboard chars from svg text (none). In practice this works.
-    a.textContent = h.textContent.trim();
-    a.href = page ? getPageHeadingUrl(page, h.id) : `#${h.id}`;
-    a.addEventListener('click', e => {
-      e.preventDefault();
-      if (page) history.pushState(null, '', getPageHeadingUrl(page, h.id));
-      focusHeading(h);
-      closePanel();
-    });
-    panel.appendChild(a);
+    panel.appendChild(makeTocLink(h, closePanel));
+    railLinks.appendChild(makeTocLink(h));
   });
   metaRow.appendChild(wrap);
+  rail.classList.remove('is-empty');
 
   toggle.addEventListener('click', e => {
     e.stopPropagation();
     panel.classList.contains('is-open') ? closePanel() : openPanel();
   });
-  document.addEventListener('click', e => {
+  tocDocumentClickHandler = e => {
     if (panel.classList.contains('is-open') && !wrap.contains(e.target)) closePanel();
-  });
-  document.addEventListener('keydown', e => {
+  };
+  tocKeydownHandler = e => {
     if (e.key === 'Escape' && panel.classList.contains('is-open')) closePanel();
-  });
+  };
+  document.addEventListener('click', tocDocumentClickHandler);
+  document.addEventListener('keydown', tocKeydownHandler);
 
-  const links = panel.querySelectorAll('.toc-link');
-  tocObserver = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        const id = entry.target.id;
-        links.forEach(l => l.classList.toggle('active', l.dataset.headingId === id));
-      }
-    });
-  }, { rootMargin: `-${56 + 40 + 20}px 0px -68% 0px`, threshold: 0 });
+  const links = [...document.querySelectorAll('.toc-link')];
+  const setActiveLink = id => {
+    links.forEach(link => link.classList.toggle('active', link.dataset.headingId === id));
+  };
+  const getActiveHeading = () => {
+    const offset = 136;
+    const bottomSlack = 4;
+    if (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - bottomSlack) {
+      return headings[headings.length - 1];
+    }
+
+    let active = headings[0];
+    for (const heading of headings) {
+      if (heading.getBoundingClientRect().top <= offset) active = heading;
+      else break;
+    }
+    return active;
+  };
+  let tocFrame = 0;
+  const updateActive = () => {
+    tocFrame = 0;
+    setActiveLink(getActiveHeading().id);
+  };
+  const scheduleActiveUpdate = () => {
+    if (tocFrame) return;
+    tocFrame = window.requestAnimationFrame(updateActive);
+  };
+
+  tocScrollHandler = scheduleActiveUpdate;
+  tocResizeHandler = scheduleActiveUpdate;
+  window.addEventListener('scroll', tocScrollHandler, { passive: true });
+  window.addEventListener('resize', tocResizeHandler);
+  tocObserver = new IntersectionObserver(scheduleActiveUpdate, {
+    rootMargin: '-136px 0px -62% 0px',
+    threshold: [0, 1],
+  });
 
   headings.forEach(h => tocObserver.observe(h));
+  updateActive();
 }
 
 /* ─── Prev/next ─────────────────────────────────────────────────────────── */
@@ -1374,6 +1445,7 @@ function renderPageNav(file) {
 
 /* ─── Helpers ───────────────────────────────────────────────────────────── */
 function showLoading() {
+  resetToc();
   document.getElementById('loading').style.display     = 'flex';
   document.getElementById('error-state').style.display = 'none';
   document.getElementById('article').style.display     = 'none';
@@ -1385,6 +1457,7 @@ function hideLoading() { document.getElementById('loading').style.display = 'non
 function showError(msg, detail = '') {
   // Error state lives inside article-view; make sure the right view is showing.
   showArticleView();
+  resetToc();
   document.getElementById('loading').style.display     = 'none';
   document.getElementById('article').style.display     = 'none';
   document.getElementById('page-nav').style.display    = 'none';

--- a/site/index.html
+++ b/site/index.html
@@ -154,6 +154,13 @@
       <article id="article" style="display:none"></article>
       <div id="page-nav" style="display:none"></div>
     </main>
+
+    <aside id="toc-rail" aria-label="On this page">
+      <div class="toc-rail-inner">
+        <div class="toc-rail-title">On this page</div>
+        <nav id="toc-rail-links" aria-label="Page sections"></nav>
+      </div>
+    </aside>
   </div>
 </div>
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -21,10 +21,11 @@
       --red:        #dc2626;            /* error */
       --red-deep:   #991b1b;            /* error deep */
 
-      --sidebar-w:   272px;
-      --content-max: 920px;   /* fills the 1280 layout (1232 inner − 272 sidebar − 40 gap) so the doc body lines up with header/footer */
-      --outer-px:    24px;
-      --layout-max:  1280px;
+      --sidebar-w:   288px;
+      --toc-w:       224px;
+      --content-max: 760px;
+      --outer-px:    32px;
+      --layout-max:  1440px;
 
       --header-h:    60px;
       --topbar-h:    var(--header-h);
@@ -495,9 +496,10 @@
       max-width: var(--layout-max);
       margin: 0 auto;
       padding: 0 var(--outer-px);
-      display: flex;
+      display: grid;
+      grid-template-columns: var(--sidebar-w) minmax(0, var(--content-max)) var(--toc-w);
       align-items: flex-start;
-      gap: 40px;
+      column-gap: clamp(32px, 4vw, 56px);
     }
 
     /* Sidebar */
@@ -593,9 +595,36 @@
 
     /* Content */
     #content {
-      flex: 1; min-width: 0;
+      min-width: 0;
       max-width: var(--content-max);
       padding: 48px 0 96px;
+    }
+
+    #toc-rail {
+      position: sticky;
+      top: var(--topbar-h);
+      max-height: calc(100vh - var(--topbar-h));
+      overflow-y: auto;
+      padding: 48px 0 40px;
+      scrollbar-width: thin;
+    }
+    #toc-rail.is-empty { visibility: hidden; }
+    .toc-rail-inner {
+      border-left: 1px solid var(--stone);
+      padding-left: 18px;
+    }
+    .toc-rail-title {
+      margin-bottom: 10px;
+      font-size: 11px;
+      font-weight: 700;
+      color: var(--ash);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+    #toc-rail-links {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
     }
 
     /* Loading / error */
@@ -741,7 +770,10 @@
       .page-feedback .pf-label { flex-basis: 100%; }
     }
 
-    .toc-wrap { position: relative; }
+    .toc-wrap {
+      position: relative;
+      display: none;
+    }
 
     .toc-toggle {
       display: inline-flex; align-items: center; gap: 6px;
@@ -788,7 +820,7 @@
     [data-theme="dark"] .toc-panel { box-shadow: 0 12px 32px rgba(0,0,0,0.6), 0 2px 6px rgba(0,0,0,0.4); }
     .toc-panel.is-open { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
     .toc-panel-label { display: none; }
-    .toc-panel .toc-link {
+    .toc-link {
       display: block;
       padding: 6px 10px;
       margin-bottom: 2px;
@@ -798,18 +830,51 @@
       text-decoration: none;
       cursor: pointer;
       border-radius: 5px;
-      transition: color var(--transition), background var(--transition);
+      position: relative;
+      transition: color var(--transition), background var(--transition), transform var(--transition);
     }
-    .toc-panel .toc-link.level-3 {
+    .toc-link::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 7px;
+      bottom: 7px;
+      width: 2px;
+      border-radius: 999px;
+      background: var(--green);
+      opacity: 0;
+      transform: scaleY(0.45);
+      transition: opacity 0.18s ease, transform 0.18s ease;
+    }
+    .toc-link.level-3 {
       padding-left: 22px;
       font-size: 12.5px;
       color: var(--ash);
     }
-    .toc-panel .toc-link:hover,
-    .toc-panel .toc-link.active {
+    .toc-link:hover,
+    .toc-link.active {
       color: var(--ink);
       background: var(--linen);
       font-weight: 500;
+    }
+    .toc-link.active::before {
+      opacity: 1;
+      transform: scaleY(1);
+    }
+    #toc-rail-links .toc-link {
+      padding: 5px 8px 5px 12px;
+      margin-bottom: 0;
+      background: transparent;
+    }
+    #toc-rail-links .toc-link:hover,
+    #toc-rail-links .toc-link.active {
+      background: transparent;
+    }
+    #toc-rail-links .toc-link.active {
+      transform: translateX(2px);
+    }
+    #toc-rail-links .toc-link.level-3 {
+      padding-left: 24px;
     }
 
     #article h2 {
@@ -1098,6 +1163,17 @@
       padding-left: 6px;
       margin-left: -6px;
     }
+    @media (prefers-reduced-motion: reduce) {
+      .toc-link,
+      .toc-link::before,
+      .heading-highlight {
+        transition: none;
+        animation: none;
+      }
+      #toc-rail-links .toc-link.active {
+        transform: none;
+      }
+    }
 
     /* Mobile drawer */
     #hamburger { display: none; }
@@ -1140,9 +1216,29 @@
 
     /* Responsive */
     #hamburger { display: none; }
+    @media (max-width: 1320px) {
+      :root {
+        --outer-px: 24px;
+      }
+      #body {
+        grid-template-columns: var(--sidebar-w) minmax(0, 920px);
+        column-gap: clamp(28px, 4vw, 40px);
+        max-width: 1280px;
+      }
+      #content {
+        max-width: 920px;
+      }
+      #toc-rail {
+        display: none;
+      }
+      .toc-wrap {
+        display: block;
+      }
+    }
     @media (max-width: 820px) {
       .card-grid { grid-template-columns: 1fr 1fr; }
       #sidebar { display: none; }
+      #body { grid-template-columns: minmax(0, 1fr); }
       #hamburger { display: flex; }
       .navbar-link { font-size: 0.8rem; }
       .navbar-cta { font-size: 0.75rem; padding: 0.35rem 0.75rem; }


### PR DESCRIPTION
## Summary
- Adds a persistent wide-screen `On this page` right rail to article pages.
- Realigns the docs shell to a wider three-column grid with the left docs nav moved farther left.
- Keeps the existing compact TOC dropdown for narrower widths and mobile.
- Refactors TOC generation so route changes clear/rebuild both desktop and compact TOC mounts, with stable h2/h3 scrollspy and reduced-motion-safe active styling.

## Verification
- `npm run docs:build:auto`
- `npm run docs:test:static-routes`
- `node --check site/app.js`
- Served `.site` locally at `http://127.0.0.1:4321/`.

## Browser inspection note
Attempted Playwright inspection for desktop/tablet/mobile against `docs/reference/api/issues`, but local Chromium could not launch because the container is missing `libatk-1.0.so.0`; `npx playwright install-deps chromium` could not complete because sudo requires a password. Existing QA follow-up should perform real browser review on the PR/canary.

## Canary
No Cloudflare canary URL is available from this local PR creation step yet.
