### PR TITLE
Canonicalize docs route redirects

### DIFF
--- a/scripts/verify-static-routes.mjs
+++ b/scripts/verify-static-routes.mjs
@@ -39,14 +39,15 @@ try {
     "skills route did not get a route-specific title",
   );
   assert(
-    skillsHtml.includes('<link rel="canonical" href="https://docs.paperclip.ing/reference/skills" />'),
+    skillsHtml.includes('<link rel="canonical" data-seo-managed href="https://docs.paperclip.ing/reference/skills/" />'),
     "skills route canonical URL is missing or incorrect",
   );
   assert(!skillsHtml.match(/rel="canonical"[^>]+#/), "canonical URL contains a hash");
   assert(skillsHtml.includes("<h1>Skills Reference</h1>"), "skills route is missing crawler-visible page content");
   assert(skillsHtml.includes("the file shape on disk"), "skills route body is missing expected docs copy");
-  assert(skillsHtml.includes('href="/styles.css"'), "nested route does not load stylesheet from the release base path");
-  assert(skillsHtml.includes('src="/app.js"'), "nested route does not load app JS from the release base path");
+  assert(skillsHtml.includes('<base data-seo-base href="/" />'), "nested route is missing the release base path");
+  assert(skillsHtml.includes('href="styles.css"'), "nested route does not load stylesheet from the release base path");
+  assert(skillsHtml.includes('src="app.js"'), "nested route does not load app JS from the release base path");
 
   const appJs = read("app.js");
   assert(!appJs.includes("/#/"), "generated app JS still contains primary hash route URLs");
@@ -72,6 +73,17 @@ try {
 
   const robots = read("robots.txt");
   assert(robots.includes("Sitemap: https://docs.paperclip.ing/sitemap.xml"), "robots.txt is missing sitemap reference");
+
+  const redirects = read("_redirects");
+  const canonicalRedirect = "/guides/getting-started/five-minute-path /guides/getting-started/five-minute-path/ 301";
+  assert(
+    redirects.includes(canonicalRedirect),
+    "Cloudflare redirects are missing the no-slash canonical redirect for the quickstart path",
+  );
+  assert(
+    redirects.indexOf(canonicalRedirect) < redirects.indexOf("/* /index.html 200"),
+    "canonical route redirects must appear before the SPA fallback rewrite",
+  );
 
   const deployGuide = read("DEPLOY.md");
   assert(deployGuide.includes("Cloudflare Pages"), "deploy guide is missing Cloudflare Pages guidance");

--- a/site/build-release.mjs
+++ b/site/build-release.mjs
@@ -598,8 +598,27 @@ Sitemap: ${siteUrlForPath(siteUrl, basePath, "sitemap.xml")}
 `;
 }
 
-function buildCloudflareRedirects() {
-  return `# Serve generated files first; fall back to the SPA shell for client routes.
+function cloudflarePathForRoute(basePath, routePath, { trailingSlash = false } = {}) {
+  const baseKey = normalizeRouteKey(getDeploymentBasePath(basePath));
+  const routeKey = normalizeRouteKey(routePath);
+  const key = [baseKey, routeKey].filter(Boolean).join("/");
+  return `/${key}${trailingSlash ? "/" : ""}`;
+}
+
+function buildCloudflareRedirects({ basePath, pages }) {
+  const routeRedirects = pages
+    .map(({ page }) => {
+      const sourcePath = cloudflarePathForRoute(basePath, page.slug);
+      const destinationPath = cloudflarePathForRoute(basePath, page.slug, { trailingSlash: true });
+      return `${sourcePath} ${destinationPath} 301`;
+    })
+    .join("\n");
+
+  return `# Canonical docs URLs include trailing slashes. Keep no-slash requests
+# on a normal one-hop 301 instead of Cloudflare Pages' implicit directory 308.
+${routeRedirects}
+
+# Serve generated files first; fall back to the SPA shell for client routes.
 /* /index.html 200
 `;
 }
@@ -819,7 +838,6 @@ async function main() {
   await fs.writeFile(path.join(options.outDir, ".htaccess"), buildHtaccess(options.basePath));
   await fs.writeFile(path.join(options.outDir, "nginx.conf.example"), buildNginxConfig(options.basePath));
   await fs.writeFile(path.join(options.outDir, "DEPLOY.md"), buildDeployGuide(options.basePath));
-  await fs.writeFile(path.join(options.outDir, "_redirects"), buildCloudflareRedirects());
   await fs.writeFile(path.join(options.outDir, "_headers"), buildCloudflareHeaders());
 
   // Copy markdown files, stripping YAML frontmatter, and collect per-file
@@ -847,6 +865,10 @@ async function main() {
   await fs.writeFile(path.join(options.outDir, "content.json"), `${JSON.stringify(releaseNav, null, 2)}\n`);
 
   const pageMetadata = await pageMetadataForNav(releaseNav, options.outDir, options.siteUrl, options.basePath);
+  await fs.writeFile(path.join(options.outDir, "_redirects"), buildCloudflareRedirects({
+    basePath: options.basePath,
+    pages: pageMetadata,
+  }));
   const rootMetadata = {
     title: "Paperclip Docs",
     description: defaultSeoDescription,


### PR DESCRIPTION
## Summary

- Generates explicit Cloudflare Pages `_redirects` entries for every slash-terminated static docs route.
- Sends no-trailing-slash docs URLs to their canonical slash URL with a one-hop 301 before the SPA fallback.
- Extends the static-route verifier to assert those redirects are emitted and ordered before the catch-all fallback.

## Root cause

Google Search Console was inspecting the no-trailing-slash URL. The live page currently reaches content after a redirect chain, while the sitemap and canonical URL use the trailing-slash form. Making the redirect explicit in `_redirects` removes ambiguity for crawlers and keeps the canonical route consistent.

## Verification

- `npm run docs:test:static-routes`
- `git diff --check origin/main...HEAD`
