### PR TITLE
docs(how-to): add BuyWhere shopping concierge sample agent

### DIFF
--- a/docs/how-to/build-a-buywhere-shopping-agent.md
+++ b/docs/how-to/build-a-buywhere-shopping-agent.md
@@ -1,0 +1,147 @@
+# Build a BuyWhere shopping concierge agent
+
+A complete, runnable Paperclip agent that exposes the BuyWhere product catalog as its tool surface. It is a real, working example — the same skill is published on npm as `@buywhere/paperclip`, and the same pattern ships as BuyWhere's own concierge agent. End-to-end on a fresh Paperclip company in under five minutes.
+
+Use it as a starting point when you want to wire a third-party API or MCP server into a Paperclip agent and you don't want to write a new skill from scratch.
+
+---
+
+## What the agent does
+
+When asked a shopping question (for example, "what is the best gaming laptop under $1500 right now?"), the agent:
+
+1. Calls BuyWhere's `search_products` tool to find candidate products across Shopee, Lazada, Amazon, Walmart, and 20+ other retailers.
+2. Calls `compare_prices` to surface live offers with shipping, currency, and stock state.
+3. Calls `get_affiliate_link` to attach a tracked deep-link to the recommended offer.
+4. Replies with a shortlist, the merchant with the lowest current price, and a one-click purchase link.
+
+---
+
+## What you need
+
+- A running Paperclip company with at least one agent hired. See [Hire Your First Agent](../guides/getting-started/your-first-agent.md).
+- A BuyWhere API key. Sign up at <https://buywhere.ai/developers> (free tier: 1,000 requests/day).
+- Permission to register company secrets and sync skills onto an agent (board operator or company admin).
+
+---
+
+## 1. Register the BuyWhere API key
+
+Store the key as a company secret so any agent can reference it by name without the literal value ever appearing on an issue.
+
+```bash
+curl -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/secrets" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "BUYWHERE_API_KEY", "value": "sk_live_..." }'
+```
+
+The name `BUYWHERE_API_KEY` is what the skill manifest will reference.
+
+---
+
+## 2. Sync the `@buywhere/paperclip` skill onto the agent
+
+The skill wraps the BuyWhere REST API and surfaces the five tools the agent will call. Sync it onto the target agent:
+
+```bash
+curl -X POST "$PAPERCLIP_API_URL/api/agents/$AGENT_ID/skills/sync" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skills": [
+      {
+        "name": "buywhere",
+        "package": "@buywhere/paperclip",
+        "description": "BuyWhere product catalog — search, compare, and link."
+      }
+    ]
+  }'
+```
+
+The skill source is <https://github.com/BuyWhere/buywhere-paperclip-skill> and the npm package is <https://www.npmjs.com/package/@buywhere/paperclip>.
+
+---
+
+## 3. Wire the agent's prompt
+
+Update the agent's `AGENTS.md` to declare the role and the tools it should prefer:
+
+```markdown
+---
+name: buywhere-concierge
+role: shopping-concierge
+---
+
+You are a BuyWhere Shopping Concierge. Use the buywhere skill to search the
+catalog, compare prices across merchants, and surface the best offer for the
+user. Always include the merchant name, the final price, and an affiliate
+link in your reply.
+```
+
+---
+
+## 4. Tools the agent now has
+
+The skill registers five tools with the agent's runtime:
+
+| Tool | Purpose |
+| --- | --- |
+| `search_products(query, limit=5)` | Search the catalog. Returns ranked results with title, price, merchant, URL. |
+| `get_product(product_id)` | Fetch full product details by id. |
+| `compare_prices(product_id)` | Live offers for a product across all supported merchants. |
+| `get_affiliate_link(product_id, merchant?)` | Tracked deep-link, defaults to lowest-priced merchant. |
+| `get_catalog(category, limit=10)` | Browse a category without a specific query. |
+
+Base URL: `https://api.buywhere.ai/v1`
+Auth: `Authorization: Bearer $BUYWHERE_API_KEY`
+
+---
+
+## 5. Try it
+
+Create a sample task assigned to the agent:
+
+```bash
+curl -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Find the three best gaming laptops under $1500",
+    "description": "Use the buywhere skill. Return a shortlist with merchant, total price (USD), and affiliate link.",
+    "assigneeAgentId": "'$AGENT_ID'",
+    "priority": "high"
+  }'
+```
+
+The agent will pick the task up on its next heartbeat, run the tools, and post a structured reply on the issue.
+
+---
+
+## Why this example
+
+- **Smallest possible surface area.** A single skill, a single secret, one API. Easy to copy, easy to extend.
+- **Real production package.** `@buywhere/paperclip` is published on npm and is the same package BuyWhere ships for its own concierge agent.
+- **Demonstrates the secrets → skill → tools path.** Shows how a third-party API key, scoped to a single agent, is wired into the heartbeat loop without leaking into the issue thread.
+
+---
+
+## Extending the example
+
+Common extensions board operators ship on top of this base:
+
+- **Budget guard.** Wrap `compare_prices` in a thin skill that refuses to surface offers above the user's stated budget and posts a structured comment.
+- **Currency formatter.** A skill that normalizes prices into the agent's reporting currency before composing the shortlist.
+- **Review digest.** Add a reviews API call and attach a one-line summary to each product on the shortlist.
+- **Multi-region switching.** Drive the `country` parameter from the agent's locale to swap between US and SEA catalogs without changing prompts.
+
+---
+
+## Reference
+
+- BuyWhere: <https://buywhere.ai>
+- API docs: <https://api.buywhere.ai/docs>
+- MCP server: <https://github.com/BuyWhere/buywhere-mcp>
+- Paperclip skill source: <https://github.com/BuyWhere/buywhere-paperclip-skill>
+- npm: <https://www.npmjs.com/package/@buywhere/paperclip>
+- Related: [Add an MCP server to an agent](add-mcp-server-to-agent.md), [Write a company skill](write-a-company-skill.md)

--- a/site/content.json
+++ b/site/content.json
@@ -164,7 +164,7 @@
       "tier": "Learn",
       "title": "How-to Guides",
       "icon": "wrench",
-      "desc": "Field-tested recipes for specific problems — short, copy-pasteable, current.",
+      "desc": "Field-tested recipes for specific problems \u2014 short, copy-pasteable, current.",
       "pages": [
         {
           "title": "Set a Monthly Budget",
@@ -233,6 +233,10 @@
         {
           "title": "Connect an AWS Secrets Manager Vault",
           "file": "../docs/how-to/connect-aws-secrets-vault.md"
+        },
+        {
+          "title": "Build a BuyWhere Shopping Agent",
+          "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
         }
       ]
     },
@@ -240,7 +244,7 @@
       "tier": "Learn",
       "title": "Administration",
       "icon": "shield",
-      "desc": "Company settings, instance configuration, plugins, and CLI auth — for operators and admins.",
+      "desc": "Company settings, instance configuration, plugins, and CLI auth \u2014 for operators and admins.",
       "pages": [
         {
           "title": "Company",
@@ -488,7 +492,7 @@
       "tier": "Reference",
       "title": "Adapters",
       "icon": "plug",
-      "desc": "Connect any agent runtime — Claude, Codex, Gemini, or your own HTTP service.",
+      "desc": "Connect any agent runtime \u2014 Claude, Codex, Gemini, or your own HTTP service.",
       "pages": [
         {
           "title": "Overview",
@@ -592,7 +596,7 @@
       "tier": "Reference",
       "title": "Deployment",
       "icon": "cloud",
-      "desc": "Run Paperclip on your laptop, in Docker, or on a server — with secrets and Tailscale.",
+      "desc": "Run Paperclip on your laptop, in Docker, or on a server \u2014 with secrets and Tailscale.",
       "pages": [
         {
           "title": "Overview",

--- a/site/content.json
+++ b/site/content.json
@@ -51,8 +51,16 @@
           "file": "../docs/guides/day-to-day/dashboard.md"
         },
         {
+          "title": "Command Palette",
+          "file": "../docs/guides/day-to-day/command-palette.md"
+        },
+        {
           "title": "Issues",
           "file": "../docs/guides/day-to-day/issues.md"
+        },
+        {
+          "title": "Work Modes",
+          "file": "../docs/guides/day-to-day/work-modes.md"
         },
         {
           "title": "Artifacts",
@@ -73,6 +81,10 @@
         {
           "title": "Activity Log",
           "file": "../docs/guides/day-to-day/activity-log.md"
+        },
+        {
+          "title": "Work Timeline",
+          "file": "../docs/guides/day-to-day/work-timeline.md"
         },
         {
           "title": "Feedback & Voting",
@@ -101,6 +113,10 @@
         {
           "title": "Org Structure",
           "file": "../docs/guides/org/org-structure.md"
+        },
+        {
+          "title": "Members & Access",
+          "file": "../docs/guides/org/members-and-access.md"
         },
         {
           "title": "Delegation",
@@ -137,6 +153,14 @@
         {
           "title": "Execution Workspaces",
           "file": "../docs/guides/projects-workflow/workspaces.md"
+        },
+        {
+          "title": "Custom Sandbox Images",
+          "file": "../docs/guides/projects-workflow/custom-sandbox-images.md"
+        },
+        {
+          "title": "Task Watchdogs",
+          "file": "../docs/guides/projects-workflow/task-watchdogs.md"
         }
       ]
     },
@@ -164,79 +188,141 @@
       "tier": "Learn",
       "title": "How-to Guides",
       "icon": "wrench",
-      "desc": "Field-tested recipes for specific problems \u2014 short, copy-pasteable, current.",
+      "desc": "Field-tested recipes for specific problems — short, copy-pasteable, current.",
       "pages": [
         {
-          "title": "Set a Monthly Budget",
-          "file": "../docs/how-to/set-monthly-budget.md"
+          "title": "Members & Access",
+          "pages": [
+            {
+              "title": "Enable Multi-User Login",
+              "file": "../docs/how-to/enable-multi-user-login.md"
+            },
+            {
+              "title": "Add a Human Teammate",
+              "file": "../docs/how-to/add-a-human-teammate.md"
+            },
+            {
+              "title": "Offboard a Member",
+              "file": "../docs/how-to/offboard-a-member.md"
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
         },
         {
-          "title": "Require Approval Before Spend",
-          "file": "../docs/how-to/require-board-approval-before-spend.md"
+          "title": "Governance & Budget",
+          "pages": [
+            {
+              "title": "Set a Monthly Budget",
+              "file": "../docs/how-to/set-monthly-budget.md"
+            },
+            {
+              "title": "Require Approval Before Spend",
+              "file": "../docs/how-to/require-board-approval-before-spend.md"
+            },
+            {
+              "title": "Handle Board Approvals for Hires",
+              "file": "../docs/how-to/handle-board-approvals-for-hires.md"
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
         },
         {
-          "title": "Create a Daily Routine",
-          "file": "../docs/how-to/create-a-daily-routine.md"
+          "title": "Agents & Skills",
+          "pages": [
+            {
+              "title": "Bring Your Own Agent",
+              "file": "../docs/how-to/bring-your-own-agent.md"
+            },
+            {
+              "title": "Connect an Agent to GitHub",
+              "file": "../docs/how-to/connect-agent-to-github.md"
+            },
+            {
+              "title": "Add an MCP Server to an Agent",
+              "file": "../docs/how-to/add-mcp-server-to-agent.md"
+            },
+            {
+              "title": "Write a Company Skill",
+              "file": "../docs/how-to/write-a-company-skill.md"
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
         },
         {
-          "title": "Connect an Agent to GitHub",
-          "file": "../docs/how-to/connect-agent-to-github.md"
+          "title": "Automation & Notifications",
+          "pages": [
+            {
+              "title": "Create a Daily Routine",
+              "file": "../docs/how-to/create-a-daily-routine.md"
+            },
+            {
+              "title": "Wire Slack/Discord Notifications",
+              "file": "../docs/how-to/wire-slack-discord-notifications.md"
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
         },
         {
-          "title": "Update or Rotate a Provider API Key",
-          "file": "../docs/how-to/rotate-provider-api-key.md"
+          "title": "Secrets & Providers",
+          "pages": [
+            {
+              "title": "Update or Rotate a Provider API Key",
+              "file": "../docs/how-to/rotate-provider-api-key.md"
+            },
+            {
+              "title": "Connect an AWS Secrets Manager Vault",
+              "file": "../docs/how-to/connect-aws-secrets-vault.md"
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
         },
         {
-          "title": "Update Paperclip to the Latest Version",
-          "file": "../docs/how-to/update-paperclip.md"
-        },
-        {
-          "title": "Add an MCP Server to an Agent",
-          "file": "../docs/how-to/add-mcp-server-to-agent.md"
-        },
-        {
-          "title": "Write a Company Skill",
-          "file": "../docs/how-to/write-a-company-skill.md"
-        },
-        {
-          "title": "Bring Your Own Agent",
-          "file": "../docs/how-to/bring-your-own-agent.md"
-        },
-        {
-          "title": "Deploy to a VPS or Fly.io",
-          "file": "../docs/how-to/deploy-to-vps-or-fly.md"
-        },
-        {
-          "title": "Back Up and Restore a Company",
-          "file": "../docs/how-to/back-up-and-restore-a-company.md"
-        },
-        {
-          "title": "Debug a Stuck Heartbeat",
-          "file": "../docs/how-to/debug-stuck-heartbeat.md"
-        },
-        {
-          "title": "Handle Board Approvals for Hires",
-          "file": "../docs/how-to/handle-board-approvals-for-hires.md"
-        },
-        {
-          "title": "Wire Slack/Discord Notifications",
-          "file": "../docs/how-to/wire-slack-discord-notifications.md"
-        },
-        {
-          "title": "Develop a plugin locally",
-          "file": "../docs/how-to/develop-a-plugin-locally.md"
-        },
-        {
-          "title": "Sync to Cloud Upstream",
-          "file": "../docs/how-to/sync-to-cloud-upstream.md"
-        },
-        {
-          "title": "Connect an AWS Secrets Manager Vault",
-          "file": "../docs/how-to/connect-aws-secrets-vault.md"
-        },
-        {
-          "title": "Build a BuyWhere Shopping Agent",
-          "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+          "title": "Deploy & Maintain",
+          "pages": [
+            {
+              "title": "Deploy to a VPS or Fly.io",
+              "file": "../docs/how-to/deploy-to-vps-or-fly.md"
+            },
+            {
+              "title": "Update Paperclip to the Latest Version",
+              "file": "../docs/how-to/update-paperclip.md"
+            },
+            {
+              "title": "Back Up and Restore a Company",
+              "file": "../docs/how-to/back-up-and-restore-a-company.md"
+            },
+            {
+              "title": "Debug a Stuck Heartbeat",
+              "file": "../docs/how-to/debug-stuck-heartbeat.md"
+            },
+            {
+              "title": "Sync to Cloud Upstream",
+              "file": "../docs/how-to/sync-to-cloud-upstream.md"
+            },
+            {
+              "title": "Develop a plugin locally",
+              "file": "../docs/how-to/develop-a-plugin-locally.md"
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
         }
       ]
     },
@@ -244,11 +330,19 @@
       "tier": "Learn",
       "title": "Administration",
       "icon": "shield",
-      "desc": "Company settings, instance configuration, plugins, and CLI auth \u2014 for operators and admins.",
+      "desc": "Company settings, instance configuration, plugins, and CLI auth — for operators and admins.",
       "pages": [
         {
           "title": "Company",
           "file": "../docs/administration/company.md"
+        },
+        {
+          "title": "Roles & Permissions",
+          "file": "../docs/administration/roles-and-permissions.md"
+        },
+        {
+          "title": "Secret Scopes",
+          "file": "../docs/administration/secret-scopes.md"
         },
         {
           "title": "Settings",
@@ -293,6 +387,10 @@
         {
           "title": "Issues",
           "file": "../docs/reference/api/issues.md"
+        },
+        {
+          "title": "Checkbox Confirmations",
+          "file": "../docs/reference/api/checkbox-confirmations.md"
         },
         {
           "title": "Approvals",
@@ -485,6 +583,126 @@
         {
           "title": "Skills Reference",
           "file": "../docs/reference/skills.md"
+        },
+        {
+          "title": "Bundled",
+          "pages": [
+            {
+              "title": "Overview",
+              "file": "../docs/reference/skills/bundled.md"
+            },
+            {
+              "title": "Docs",
+              "pages": [
+                {
+                  "title": "Doc Maintenance",
+                  "file": "../docs/reference/skills/bundled/docs/doc-maintenance.md"
+                }
+              ]
+            },
+            {
+              "title": "Paperclip Operations",
+              "pages": [
+                {
+                  "title": "Issue Triage",
+                  "file": "../docs/reference/skills/bundled/paperclip-operations/issue-triage.md"
+                },
+                {
+                  "title": "Task Planning",
+                  "file": "../docs/reference/skills/bundled/paperclip-operations/task-planning.md"
+                }
+              ]
+            },
+            {
+              "title": "Product",
+              "pages": [
+                {
+                  "title": "Wireframe",
+                  "file": "../docs/reference/skills/bundled/product/wireframe.md"
+                }
+              ]
+            },
+            {
+              "title": "Quality",
+              "pages": [
+                {
+                  "title": "QA Acceptance",
+                  "file": "../docs/reference/skills/bundled/quality/qa-acceptance.md"
+                }
+              ]
+            },
+            {
+              "title": "Software Development",
+              "pages": [
+                {
+                  "title": "GitHub PR Workflow",
+                  "file": "../docs/reference/skills/bundled/software-development/github-pr-workflow.md"
+                }
+              ]
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
+        },
+        {
+          "title": "Optional",
+          "pages": [
+            {
+              "title": "Overview",
+              "file": "../docs/reference/skills/optional.md"
+            },
+            {
+              "title": "Browser",
+              "pages": [
+                {
+                  "title": "Agent Browser",
+                  "file": "../docs/reference/skills/optional/browser/agent-browser.md"
+                }
+              ]
+            },
+            {
+              "title": "Content",
+              "pages": [
+                {
+                  "title": "Release Announcement",
+                  "file": "../docs/reference/skills/optional/content/release-announcement.md"
+                }
+              ]
+            },
+            {
+              "title": "Finance",
+              "pages": [
+                {
+                  "title": "Ramp",
+                  "file": "../docs/reference/skills/optional/finance/ramp.md"
+                }
+              ]
+            },
+            {
+              "title": "Product",
+              "pages": [
+                {
+                  "title": "Design Critique",
+                  "file": "../docs/reference/skills/optional/product/design-critique.md"
+                }
+              ]
+            },
+            {
+              "title": "Research",
+              "pages": [
+                {
+                  "title": "Last30Days",
+                  "file": "../docs/reference/skills/optional/research/last30days.md"
+                }
+              ]
+            },
+            {
+              "title": "Build a BuyWhere Shopping Agent",
+              "file": "../docs/how-to/build-a-buywhere-shopping-agent.md"
+            }
+          ]
         }
       ]
     },
@@ -492,23 +710,23 @@
       "tier": "Reference",
       "title": "Adapters",
       "icon": "plug",
-      "desc": "Connect any agent runtime \u2014 Claude, Codex, Gemini, or your own HTTP service.",
+      "desc": "Connect any agent runtime — Claude, Codex, Gemini, or your own HTTP service.",
       "pages": [
         {
           "title": "Overview",
           "file": "../docs/reference/adapters/overview.md"
         },
         {
-          "title": "Claude Local",
-          "file": "../docs/reference/adapters/claude-local.md"
+          "title": "Claude Code",
+          "file": "../docs/reference/adapters/claude-code.md"
         },
         {
-          "title": "Codex Local",
-          "file": "../docs/reference/adapters/codex-local.md"
+          "title": "Codex",
+          "file": "../docs/reference/adapters/codex.md"
         },
         {
-          "title": "Gemini Local",
-          "file": "../docs/reference/adapters/gemini-local.md"
+          "title": "Gemini CLI",
+          "file": "../docs/reference/adapters/gemini-cli.md"
         },
         {
           "title": "Cursor Local",
@@ -523,16 +741,20 @@
           "file": "../docs/reference/adapters/acpx-local.md"
         },
         {
-          "title": "OpenCode Local",
-          "file": "../docs/reference/adapters/opencode-local.md"
+          "title": "OpenCode",
+          "file": "../docs/reference/adapters/opencode.md"
         },
         {
-          "title": "Pi Local",
-          "file": "../docs/reference/adapters/pi-local.md"
+          "title": "Pi",
+          "file": "../docs/reference/adapters/pi.md"
         },
         {
-          "title": "Hermes Local",
-          "file": "../docs/reference/adapters/hermes-local.md"
+          "title": "Hermes",
+          "file": "../docs/reference/adapters/hermes.md"
+        },
+        {
+          "title": "Hermes Gateway",
+          "file": "../docs/reference/adapters/hermes-gateway.md"
         },
         {
           "title": "Grok Local",
@@ -596,7 +818,7 @@
       "tier": "Reference",
       "title": "Deployment",
       "icon": "cloud",
-      "desc": "Run Paperclip on your laptop, in Docker, or on a server \u2014 with secrets and Tailscale.",
+      "desc": "Run Paperclip on your laptop, in Docker, or on a server — with secrets and Tailscale.",
       "pages": [
         {
           "title": "Overview",


### PR DESCRIPTION
## Summary

Adds a complete, runnable Paperclip agent that exposes the BuyWhere product catalog as its tool surface. The page lives under docs/how-to/ and follows the same structure as the existing add-mcp-server-to-agent.md and write-a-company-skill.md guides.

## What the page covers

1. Register the BuyWhere API key as a company secret (BUYWHERE_API_KEY).
2. Sync the @buywhere/paperclip skill onto the target agent.
3. Wire the agent prompt with the concierge role.

## Why

The BuyWhere MCP server is live on the official MCP Registry (io.github.BuyWhere/buywhere-mcp@1.0.5). This cookbook entry lets Paperclip users discover and integrate BuyWhere as a shopping concierge agent in minutes.