### PR TITLE
docs: move desktop app guidance to unofficial community page

### DIFF
--- a/docs/guides/getting-started/five-minute-path.md
+++ b/docs/guides/getting-started/five-minute-path.md
@@ -18,9 +18,9 @@ You'll see all four ideas (company, agent, task, heartbeat) in the next few minu
 
 Install Paperclip and grab an AI provider key. This is one-time setup and lives outside the 5-minute clock — depending on what you already have, expect 3–10 minutes.
 
-- A Mac (for the Desktop app) or any machine with Node.js 20+ (for the terminal install).
+- Any machine with Node.js 20+ — the terminal install is one command.
 - An API key from [Anthropic](https://console.anthropic.com) (for `claude_local`) or [OpenAI](https://platform.openai.com) (for `codex_local`). The installation guide walks through getting one.
-- For the `claude_local` adapter: [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed on the same Mac. Install this *before* you start the path; you'll need it in step 2.
+- For the `claude_local` adapter: [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed on the same machine. Install this *before* you start the path; you'll need it in step 2.
 
 > **Warning:** Agents make API calls that cost money. Plan on spending $5–20 to play with the product, $20–100/month for an active company. Set per-agent and company budgets before enabling heartbeats — Paperclip pauses agents automatically when they hit 100%.
 

--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -4,123 +4,20 @@ paperclip_version: v2026.529.0
 
 # Installation
 
-There are three ways to install Paperclip. Choose the one that fits how you work:
+There are two ways to install Paperclip. Choose the one that fits how you work:
 
-- **Desktop App** — a regular macOS application. Download it, open it, done. No terminal, no developer tools, no configuration files. This is the right choice if you're not a developer.
-- **Terminal** — install and run Paperclip locally from the command line. For developers who want full control over configuration and hosting on their own machine.
+- **Terminal** — install and run Paperclip locally with a single command. This is the standard way to run Paperclip on your own machine.
 - **Server / VPS** — deploy Paperclip to a cloud server (AWS, GCP, DigitalOcean, Hetzner, etc.) behind a custom domain with HTTPS. For teams and anyone who wants their instance reachable from anywhere.
 
-All three paths end up in the same place: a running Paperclip instance and the onboarding flow where you create your first company, first agent, and first piece of work.
+Both paths end up in the same place: a running Paperclip instance and the onboarding flow where you create your first company, first agent, and first piece of work.
 
 ---
 
-<!-- tabs: Desktop App (macOS), Terminal (Developer), Server / VPS -->
+<!-- tabs: Terminal, Server / VPS -->
 
-<!-- tab: Desktop App (macOS) -->
+<!-- tab: Terminal -->
 
-## Step 1 — Check which Mac you have
-
-Paperclip Desktop comes in two versions depending on your Mac's chip. If you're not sure which one you have:
-
-1. Click the **Apple menu** () in the top-left corner of your screen
-2. Click **About This Mac**
-3. Look at the line that says **Chip** or **Processor**
-   - If it says **Apple M1**, **M2**, **M3**, or **M4** — you have Apple Silicon
-   - If it says **Intel Core** — you have an Intel Mac
-
----
-
-## Step 2 — Download Paperclip Desktop
-
-Go to the [Paperclip Desktop releases page](https://github.com/aronprins/paperclip-desktop/releases/latest) and download the installer for your Mac:
-
-| My Mac has… | Download this file |
-|---|---|
-| Apple Silicon (M1/M2/M3/M4) | `Paperclip.Desktop-[version]-arm64.dmg` |
-| Intel | `Paperclip.Desktop-[version].dmg` |
-
-> **Note:** The version number in the filename will match the latest release. If you see multiple `.dmg` files, the one with `arm64` in the name is for Apple Silicon. The one without is for Intel.
-
----
-
-## Step 3 — Install the app
-
-1. Open the `.dmg` file you downloaded — it will mount like a disk image and open a window
-2. Drag the **Paperclip** icon into the **Applications** folder
-
-That's the whole installation. You can eject the `.dmg` and move it to the trash once the drag is done.
-
----
-
-## Step 4 — Open Paperclip
-
-Open Paperclip from your Applications folder, or press **Cmd+Space** and type **Paperclip**.
-
-> **Warning:** The first time you open Paperclip, macOS may show a prompt saying it can't verify the developer. This is a standard macOS warning for apps downloaded outside the App Store. Click **Open** to proceed — Paperclip is safe to run.
-
-The first launch takes 10–30 seconds while Paperclip starts its local server in the background. You'll see a loading indicator. Subsequent launches are faster.
-
----
-
-## Step 5 — Get your API key
-
-Before your agents can do any work, you need an API key. An API key is a private token — similar to a password — that allows your agents to make calls to an AI provider like Anthropic (Claude) or OpenAI. Without one, agents have no way to generate responses or take actions.
-
-> **Warning:** AI providers charge for usage. Every time an agent works, it makes API calls that cost a small amount of money. The cost depends on which model you use and how much your agents work. Paperclip lets you set budgets to keep this under control, but you should be aware of this before your agents start running.
-
-Choose your AI provider and follow the steps to get a key:
-
-<!-- tabs: Anthropic (Claude), OpenAI -->
-
-<!-- tab: Anthropic (Claude) -->
-
-Anthropic makes Claude — the AI that powers the `claude_local` adapter, which is the most common choice for Paperclip agents.
-
-1. Go to [console.anthropic.com](https://console.anthropic.com) and create an account (or sign in)
-2. In the left sidebar, click **API Keys**
-3. Click **Create Key**
-4. Give it a name you'll recognise (e.g. "Paperclip")
-5. Copy the key — it starts with `sk-ant-`
-
-> **Warning:** Copy the key immediately. Anthropic only shows it once. If you lose it, you'll need to create a new one.
-
-Store it somewhere safe — you'll add it to Paperclip as an environment variable or secret when you set up your first agent.
-
-<!-- tab: OpenAI -->
-
-OpenAI makes the models that power the `codex_local` adapter.
-
-1. Go to [platform.openai.com](https://platform.openai.com) and create an account (or sign in)
-2. Click your profile icon in the top-right, then **API keys**
-3. Click **Create new secret key**
-4. Give it a name (e.g. "Paperclip") and click **Create secret key**
-5. Copy the key — it starts with `sk-`
-
-> **Warning:** Copy the key immediately. OpenAI only shows it once. If you lose it, you'll need to create a new one.
-
-<!-- /tabs -->
-
-You don't need to enter the key into Paperclip yet. You'll wire it up when you configure your first agent in the next guide.
-
----
-
-## Step 6 — Choose Local or Remote mode
-
-When Paperclip Desktop opens, it asks how you want to connect:
-
-**Local mode** runs a complete Paperclip instance directly on your Mac. Your agents run on your machine, all data stays local, and nothing is sent to an external server (beyond the API calls your agents make to Anthropic or OpenAI). This is the right choice when you're getting started.
-
-**Remote mode** connects the Desktop app to a Paperclip instance running on another machine — a team server, a cloud host, or a colleague's computer. You'll only need this if someone has already set up a shared Paperclip instance that you're connecting to.
-
-For now, choose **Local**. You can always connect to a remote instance later from the app's settings.
-
-After selecting Local, Paperclip finishes starting up and takes you into onboarding (or a start screen with a **New Company** button). That's expected. You haven't created a company yet.
-
----
-
-<!-- tab: Terminal (Developer) -->
-
-> **Note:** This path is for developers who are comfortable working in a terminal. If that's not you, use the **Desktop App** tab instead — it covers the same ground without any of this.
+> **Note:** Don't worry if you don't think of yourself as a terminal person — this path is one command, and the steps below walk through everything it needs.
 
 ---
 
@@ -176,9 +73,51 @@ You'll land in Paperclip ready to start onboarding. You haven't created a compan
 
 ---
 
+## Step 5 — Get your API key
+
+Before your agents can do any work, you need an API key. An API key is a private token — similar to a password — that allows your agents to make calls to an AI provider like Anthropic (Claude) or OpenAI. Without one, agents have no way to generate responses or take actions.
+
+> **Warning:** AI providers charge for usage. Every time an agent works, it makes API calls that cost a small amount of money. The cost depends on which model you use and how much your agents work. Paperclip lets you set budgets to keep this under control, but you should be aware of this before your agents start running.
+
+Choose your AI provider and follow the steps to get a key:
+
+<!-- tabs: Anthropic (Claude), OpenAI -->
+
+<!-- tab: Anthropic (Claude) -->
+
+Anthropic makes Claude — the AI that powers the `claude_local` adapter, which is the most common choice for Paperclip agents.
+
+1. Go to [console.anthropic.com](https://console.anthropic.com) and create an account (or sign in)
+2. In the left sidebar, click **API Keys**
+3. Click **Create Key**
+4. Give it a name you'll recognise (e.g. "Paperclip")
+5. Copy the key — it starts with `sk-ant-`
+
+> **Warning:** Copy the key immediately. Anthropic only shows it once. If you lose it, you'll need to create a new one.
+
+Store it somewhere safe — you'll add it to Paperclip as an environment variable or secret when you set up your first agent.
+
+<!-- tab: OpenAI -->
+
+OpenAI makes the models that power the `codex_local` adapter.
+
+1. Go to [platform.openai.com](https://platform.openai.com) and create an account (or sign in)
+2. Click your profile icon in the top-right, then **API keys**
+3. Click **Create new secret key**
+4. Give it a name (e.g. "Paperclip") and click **Create secret key**
+5. Copy the key — it starts with `sk-`
+
+> **Warning:** Copy the key immediately. OpenAI only shows it once. If you lose it, you'll need to create a new one.
+
+<!-- /tabs -->
+
+You don't need to enter the key into Paperclip yet. You'll wire it up when you configure your first agent in the next guide.
+
+---
+
 <!-- tab: Server / VPS -->
 
-> **Note:** This path is for deploying Paperclip to an internet-facing server behind a domain name, with login required. You'll need SSH access to a Linux VPS, a registered domain name, and a little comfort with the command line. If you only need Paperclip for yourself on your own Mac, use the **Desktop App** tab instead.
+> **Note:** This path is for deploying Paperclip to an internet-facing server behind a domain name, with login required. You'll need SSH access to a Linux VPS, a registered domain name, and a little comfort with the command line. If you only need Paperclip for yourself on your own machine, use the **Terminal** tab instead.
 
 Any Linux VPS with 1 vCPU and 2 GB of RAM is enough to get started. These instructions use **Ubuntu 22.04 / 24.04 LTS** as the reference distribution — commands on AWS EC2, Google Cloud Compute Engine, DigitalOcean Droplets, Hetzner Cloud, Linode, and similar providers are effectively identical.
 
@@ -453,7 +392,7 @@ Optional flags: `--expires-hours N` to change link lifetime, `--base-url <URL>` 
 
 ## Step 10 — Get your API key
 
-You still need an Anthropic or OpenAI key for your agents to do any work. Follow the **Get your API key** step in the Desktop App tab — it's identical for server deployments. Paste the key into Paperclip's Secrets UI once you're signed in; it will be encrypted with the master key from Step 5 and referenced by the adapter config.
+You still need an Anthropic or OpenAI key for your agents to do any work. Follow the **Get your API key** step in the Terminal tab — it's identical for server deployments. Paste the key into Paperclip's Secrets UI once you're signed in; it will be encrypted with the master key from Step 5 and referenced by the adapter config.
 
 ---
 
@@ -485,19 +424,6 @@ Common errors:
 
 ---
 
-## Connecting the Desktop app to your server
-
-Once your server is live, anyone on the team can use the macOS Desktop app as a thin client:
-
-1. Install the Desktop app (see the Desktop App tab).
-2. On the first-launch screen, choose **Remote**.
-3. Enter `https://paperclip.example.com` as the instance URL.
-4. Sign in with the account you created during the board claim.
-
-The Desktop app becomes a UI shell over your VPS — everyone on the team sees the same companies, agents, and issues.
-
----
-
 <!-- /tabs -->
 
 ---
@@ -507,3 +433,7 @@ The Desktop app becomes a UI shell over your VPS — everyone on the team sees t
 Paperclip is running. The next guide walks you through creating your first company, setting a goal if you have one ready, and getting it ready for agents.
 
 [Create Your First Company →](./your-first-company.md)
+
+---
+
+> **Note:** There is also an **unofficial, community-maintained desktop app** for macOS that wraps Paperclip in a regular Mac application. It is not built or supported by the Paperclip team. If you're curious, see [Community Desktop App](../../how-to/community-desktop-app.md).

--- a/docs/guides/power/export-import.md
+++ b/docs/guides/power/export-import.md
@@ -180,6 +180,6 @@ After an import:
 
 ## You're set
 
-Export and import give you durable, shareable backups of everything you've built. The final guide covers terminal setup — for developers who want to run Paperclip outside the Desktop App.
+Export and import give you durable, shareable backups of everything you've built. The final guide covers terminal setup — for developers who want deeper control over how Paperclip runs.
 
 [Terminal Setup →](./terminal-setup.md)

--- a/docs/guides/power/terminal-setup.md
+++ b/docs/guides/power/terminal-setup.md
@@ -1,6 +1,6 @@
 # Terminal Setup
 
-> **Note:** This guide is for developers comfortable with a terminal. If you're not a developer, use the [Desktop App installation guide](../getting-started/installation.md) instead — it covers the full setup without any of this.
+> **Note:** This guide goes deeper than the standard setup. If you're installing Paperclip for the first time, start with the [Installation guide](../getting-started/installation.md) — it covers the one-command install step by step.
 
 Paperclip runs as a Node.js server. The onboarding command handles the full setup in one step.
 

--- a/docs/guides/welcome/glossary.md
+++ b/docs/guides/welcome/glossary.md
@@ -118,7 +118,7 @@ The visual representation of your agent hierarchy. The CEO is at the top; direct
 
 ### Paperclip Desktop
 
-The macOS application for Paperclip. It packages a full Paperclip instance into a regular Mac app — drag it to Applications, open it, and Paperclip is running. No terminal or developer setup required. Paperclip Desktop is the recommended starting point for non-developers.
+An **unofficial, community-maintained** macOS application that packages a Paperclip instance into a regular Mac app. It is not built or supported by the Paperclip team; the supported install paths are the terminal and server installs in the [Installation guide](../getting-started/installation.md). See [Community Desktop App](../../how-to/community-desktop-app.md).
 
 ### Project
 

--- a/docs/guides/welcome/what-is-paperclip.md
+++ b/docs/guides/welcome/what-is-paperclip.md
@@ -38,22 +38,16 @@ The dashboard is your control centre. At a glance you can see which agents are a
 
 ## Who is it for?
 
-**If you're not a developer** — Paperclip has a desktop app for macOS that works like any other application. Download it, open it, and your Paperclip instance is running. No terminal, no configuration files, no installation steps beyond dragging an icon to your Applications folder. You'll need an API key from Anthropic or OpenAI (the services that power the AI agents), but the guides here walk you through getting one.
+**If you're not a developer** — installing Paperclip is a single command in the terminal, and the [Installation guide](../getting-started/installation.md) walks you through every step, including the one-time setup it needs. You'll need an API key from Anthropic or OpenAI (the services that power the AI agents), and the guides here walk you through getting one. Once Paperclip is running, everything happens in a friendly web interface — no terminal required day to day.
 
-**If you are a developer** — you can run Paperclip from the terminal with a single command, self-host it on your own infrastructure, connect any AI runtime via the adapter system, and extend it with plugins. The non-developer guides still apply to you — the difference is just in how you install it.
+**If you are a developer** — you can run Paperclip from the terminal with a single command, self-host it on your own infrastructure, connect any AI runtime via the adapter system, and extend it with plugins.
 
 ---
 
 ## What you need to get started
 
-**On macOS (no terminal required):**
-- A Mac running macOS 12 or later
+- Node.js 20 or later (macOS, Linux, or Windows)
 - An API key from [Anthropic](https://console.anthropic.com) or [OpenAI](https://platform.openai.com) — the guide covers how to get one
-- The Paperclip Desktop app — free to download
-
-**On any platform (terminal required):**
-- Node.js 20 or later
-- An API key from your chosen AI provider
 
 > **Warning:** Using AI agents costs money. Anthropic and OpenAI charge per use, and an active agent team can spend $20–100+ per month depending on how many agents you run and how often they work. You'll set budgets in Paperclip to keep spending under control — but be aware of this before you start.
 
@@ -69,6 +63,6 @@ The AI itself lives in the agents you configure (Claude, Codex, or others). Pape
 
 ## Ready to install?
 
-The next guide walks you through installing Paperclip — either via the Desktop app (no terminal needed) or the command line.
+The next guide walks you through installing Paperclip — a single command on your own machine, or a full server deployment for teams.
 
 [Go to Installation →](../getting-started/installation.md)

--- a/docs/how-to/community-desktop-app.md
+++ b/docs/how-to/community-desktop-app.md
@@ -1,0 +1,105 @@
+---
+paperclip_version: v2026.707.0
+---
+
+# Community Desktop App (unofficial)
+
+> **Warning:** The Paperclip Desktop app is a **community-maintained, unofficial project**. It is not built, released, or supported by the Paperclip team. It lives at [`aronprins/paperclip-desktop`](https://github.com/aronprins/paperclip-desktop) and is packaged and versioned separately from Paperclip itself. If you hit problems with the app shell (installing, launching, updating), report them on that repository — not on the main Paperclip issue tracker.
+
+The community desktop app wraps a full Paperclip instance in a regular macOS application: drag it to Applications, open it, and Paperclip is running — no terminal required. Some people like that convenience, and this page collects everything you need to install, run, and update it.
+
+The **officially supported ways to run Paperclip** are the [Terminal and Server / VPS installs](../guides/getting-started/installation.md). Everything else in these docs assumes one of those. Once the app is running, though, the product is identical — companies, agents, issues, and budgets all work the same regardless of how the instance was started.
+
+---
+
+## Install the app
+
+### Step 1 — Check which Mac you have
+
+The app comes in two builds depending on your Mac's chip. If you're not sure which one you have:
+
+1. Click the **Apple menu** () in the top-left corner of your screen
+2. Click **About This Mac**
+3. Look at the line that says **Chip** or **Processor**
+   - If it says **Apple M1**, **M2**, **M3**, or **M4** — you have Apple Silicon
+   - If it says **Intel Core** — you have an Intel Mac
+
+### Step 2 — Download the installer
+
+Go to the community [releases page](https://github.com/aronprins/paperclip-desktop/releases/latest) and download the installer for your Mac:
+
+| My Mac has… | Download this file |
+|---|---|
+| Apple Silicon (M1/M2/M3/M4) | `Paperclip.Desktop-[version]-arm64.dmg` |
+| Intel | `Paperclip.Desktop-[version].dmg` |
+
+> **Note:** The version number in the filename will match the latest release. If you see multiple `.dmg` files, the one with `arm64` in the name is for Apple Silicon. The one without is for Intel.
+
+### Step 3 — Install and open
+
+1. Open the `.dmg` file you downloaded — it will mount like a disk image and open a window
+2. Drag the **Paperclip** icon into the **Applications** folder
+3. Open Paperclip from your Applications folder, or press **Cmd+Space** and type **Paperclip**
+
+> **Warning:** The first time you open the app, macOS may show a prompt saying it can't verify the developer. That's the standard macOS warning for apps downloaded outside the App Store — and because this is a community build, you should make your own judgement about whether you trust it before clicking **Open**.
+
+The first launch takes 10–30 seconds while the app starts its bundled Paperclip server in the background. Subsequent launches are faster.
+
+---
+
+## Choose Local or Remote mode
+
+When the app opens, it asks how you want to connect:
+
+**Local mode** runs a complete Paperclip instance directly on your Mac. Your agents run on your machine, all data stays local, and nothing is sent to an external server (beyond the API calls your agents make to Anthropic or OpenAI).
+
+**Remote mode** connects the app to a Paperclip instance running on another machine — a team server, a cloud host, or a colleague's computer. The app becomes a thin UI shell over that instance.
+
+After selecting Local, the app finishes starting up and takes you into onboarding. From there, follow the normal guides: you'll need an [API key](../guides/getting-started/installation.md) from Anthropic or OpenAI before agents can do any work, and then you can [create your first company](../guides/getting-started/your-first-company.md).
+
+### Connecting to a server you deployed
+
+If your team runs a [Server / VPS install](../guides/getting-started/installation.md), anyone can point the app at it:
+
+1. Install the app (steps above).
+2. On the first-launch screen, choose **Remote**.
+3. Enter your instance URL (e.g. `https://paperclip.example.com`).
+4. Sign in with your account on that instance.
+
+Everyone connecting this way sees the same companies, agents, and issues — the server is the source of truth.
+
+---
+
+## Updating
+
+The app auto-updates itself; you don't run any commands.
+
+1. On launch, it checks GitHub Releases for a newer build of [`paperclip-desktop`](https://github.com/aronprins/paperclip-desktop/releases).
+2. If a newer version exists, it prompts you to download it. Approve the download.
+3. The update installs **the next time you quit the app**. Quit and reopen to land on the new version.
+
+> **Note:** Auto-download is opt-in (you have to click the prompt), but install-on-quit is automatic once the download is approved. If you skipped the download prompt, the app will offer it again on the next launch.
+
+**To force an immediate check**, open the **Paperclip** menu in the macOS menu bar and click **Check for Updates**.
+
+**To verify your current version**, open the **Paperclip** menu → **About Paperclip**, or hover the small **`v`** badge at the bottom of the left sidebar inside the UI.
+
+> **Tip:** Community releases follow the same calendar version as the Paperclip CLI, but they're packaged separately and may lag the CLI by a day or two. If you need a fix the moment it ships, the [terminal install](../guides/getting-started/installation.md) is always current.
+
+---
+
+## Troubleshooting
+
+**The app never prompts for an update** — Make sure you're on the network and that a newer release actually exists at [paperclip-desktop/releases](https://github.com/aronprins/paperclip-desktop/releases). If the release feed is empty, the updater logs a warning and skips silently. Reopen the app on a new release day.
+
+**You updated but want to roll back** — Download the previous installer from the [releases page](https://github.com/aronprins/paperclip-desktop/releases) and reinstall over the current app. Rollback is safe for code, but a forward-only migration may have already rewritten your database — restore a pre-update DB backup if so (see [Back Up and Restore a Company](./back-up-and-restore-a-company.md)).
+
+**Anything else** — For problems with the app shell itself, file an issue on the [community repository](https://github.com/aronprins/paperclip-desktop/issues). For problems with Paperclip the product (agents, issues, budgets, the UI), the rest of these docs and the [main repository](https://github.com/paperclipai/paperclip) apply as usual.
+
+---
+
+## Related
+
+- [Installation](../guides/getting-started/installation.md) — the officially supported Terminal and Server / VPS installs.
+- [Update Paperclip](./update-paperclip.md) — updating the supported install paths.
+- [Back Up and Restore a Company](./back-up-and-restore-a-company.md) — take snapshots of your data whichever way you run Paperclip.

--- a/docs/how-to/update-paperclip.md
+++ b/docs/how-to/update-paperclip.md
@@ -22,31 +22,14 @@ Every stable release has notes at `releases/vYYYY.MDD.P.md` in the parent repo a
 
 | Install path | How to tell | Which section below |
 |---|---|---|
-| Desktop App (macOS) | You launch Paperclip from the Applications folder. | [Path A](#path-a--desktop-app-macos) |
-| Terminal (`npx paperclipai`) | You run `npx paperclipai run` (or it's wrapped by systemd). | [Path B](#path-b--terminal--npx) |
-| Git clone | You ran `git clone`, then `pnpm install && pnpm dev`. | [Path C](#path-c--git-clone--self-hosted) |
+| Terminal (`npx paperclipai`) | You run `npx paperclipai run` (or it's wrapped by systemd). | [Path A](#path-a--terminal--npx) |
+| Git clone | You ran `git clone`, then `pnpm install && pnpm dev`. | [Path B](#path-b--git-clone--self-hosted) |
+
+> **Note:** Using the unofficial, community-maintained desktop app? It updates itself — see [Community Desktop App](./community-desktop-app.md#updating).
 
 ---
 
-## Path A — Desktop App (macOS)
-
-The desktop app auto-updates. You don't run any commands.
-
-1. Open Paperclip. On launch, it checks GitHub Releases for a newer build of [`paperclip-desktop`](https://github.com/aronprins/paperclip-desktop/releases).
-2. If a newer version exists, Paperclip prompts you to download it. Approve the download.
-3. The update installs **the next time you quit Paperclip**. Quit and reopen to land on the new version.
-
-> **Note:** Auto-download is opt-in (you have to click the prompt), but install-on-quit is automatic once the download is approved. If you skipped the download prompt, Paperclip will offer it again on the next launch.
-
-**To force an immediate check**, open the **Paperclip** menu in the macOS menu bar and click **Check for Updates**. The updater runs the same check that fires on launch and prompts you if something newer is available.
-
-**To verify your current version**, open the **Paperclip** menu → **About Paperclip**.
-
-> **Tip:** Desktop App releases follow the same calendar version as the CLI, but they're packaged separately. The desktop release may lag the CLI by a day or two while installers are notarised.
-
----
-
-## Path B — Terminal / `npx`
+## Path A — Terminal / `npx`
 
 The `paperclipai` CLI is a regular npm package. Updating means refreshing what `npx` (or your global install) resolves.
 
@@ -117,7 +100,7 @@ sudo journalctl -u paperclip -n 50 --no-pager
 
 ---
 
-## Path C — Git clone / self-hosted
+## Path B — Git clone / self-hosted
 
 This is the developer path — you ran `git clone https://github.com/paperclipai/paperclip` and run `pnpm dev` directly.
 
@@ -165,7 +148,7 @@ git pull
 
 Regardless of path:
 
-1. **Check the running version.** In the UI, hover the small **`v`** badge at the bottom of the left sidebar (next to the Documentation link and the settings/theme icons) — the tooltip shows the full server version, e.g. `v2026.525.0`. Desktop App users can also open the **Paperclip** menu → **About Paperclip**. CLI users can run `paperclipai --version`.
+1. **Check the running version.** In the UI, hover the small **`v`** badge at the bottom of the left sidebar (next to the Documentation link and the settings/theme icons) — the tooltip shows the full server version, e.g. `v2026.525.0`. CLI users can run `paperclipai --version`.
 2. **Open the dashboard.** Confirm the UI loads, your companies and agents are present, and nothing renders as an error state.
 3. **Trigger one heartbeat.** Assign a small task to an existing agent or wait for the next scheduled heartbeat. Watch the run log for a successful turn. This confirms adapters still launch under the new binary.
 
@@ -186,9 +169,7 @@ npx paperclipai@latest --version
 
 **Agents stop running after the update** — Check the run log for adapter errors. New releases occasionally tighten env-var validation or require a newer adapter binary (Claude Code, Codex, etc.). Update those binaries on the host and re-test.
 
-**Desktop App never prompts for an update** — Make sure you're on the network and that a newer release actually exists at [paperclip-desktop/releases](https://github.com/aronprins/paperclip-desktop/releases). If the desktop release feed is empty, the updater logs a warning and skips silently. Reopen the app on a new release day.
-
-**You updated but want to roll back** — For npm: `npm install -g paperclipai@<previous-version>` or `npx paperclipai@<previous-version> run`. For git clone: `git checkout <previous-tag>`, then `pnpm install` and restart. For the Desktop App: download the previous installer from the [releases page](https://github.com/aronprins/paperclip-desktop/releases) and reinstall over the current app. Rollback is safe for code, but a forward-only migration may have already rewritten your database — restore the pre-update DB backup if so.
+**You updated but want to roll back** — For npm: `npm install -g paperclipai@<previous-version>` or `npx paperclipai@<previous-version> run`. For git clone: `git checkout <previous-tag>`, then `pnpm install` and restart. Rollback is safe for code, but a forward-only migration may have already rewritten your database — restore the pre-update DB backup if so.
 
 ---
 

--- a/site/content.json
+++ b/site/content.json
@@ -297,6 +297,10 @@
             {
               "title": "Develop a plugin locally",
               "file": "../docs/how-to/develop-a-plugin-locally.md"
+            },
+            {
+              "title": "Community Desktop App (unofficial)",
+              "file": "../docs/how-to/community-desktop-app.md"
             }
           ]
         }

--- a/site/styles.css
+++ b/site/styles.css
@@ -43,20 +43,20 @@
       --transition: 0.2s ease;
     }
 
-    /* ─── Dark theme — warm charcoal + white text ────────────── */
+    /* ─── Dark theme — warm charcoal + manila cream ──────────── */
     [data-theme="dark"] {
       --white:      #1f1d1a;            /* surface */
       --linen:      #141413;            /* page background — charcoal */
       --parchment:  #2a2724;            /* raised surface */
       --stone:      #2f2c28;            /* rule / border */
       --stone-dark: #3a3836;            /* border hover */
-      --ink:        #ffffff;            /* primary text */
+      --ink:        #f3e6c4;            /* manila — primary text */
       --graphite:   #9a958a;            /* secondary text (brand --text-2 dark) */
       --ash:        #8a8579;            /* muted text — raised from brand #6E6960 for WCAG AA (~5:1) since --ash is reused for normal-size text */
       --void:       #0d0d0d;
       --mint:       rgba(34,197,94,0.12);
     }
-    [data-theme="dark"] #article pre { background: #0d0d0d; color: #ffffff; }
+    [data-theme="dark"] #article pre { background: #0d0d0d; color: #f3e6c4; }
     [data-theme="dark"] #header { background: rgba(20,20,19,0.92); backdrop-filter: blur(8px); }
 
     html {
@@ -168,8 +168,8 @@
       transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
     }
     .navbar-cta:hover { background: var(--white); color: var(--ink); border-color: var(--ink); }
-    [data-theme="dark"] .navbar-cta { color: #141413; background: #ffffff; border-color: #ffffff; }
-    [data-theme="dark"] .navbar-cta:hover { background: transparent; color: #ffffff; border-color: #ffffff; }
+    [data-theme="dark"] .navbar-cta { color: #141413; background: #f3e6c4; border-color: #f3e6c4; }
+    [data-theme="dark"] .navbar-cta:hover { background: transparent; color: #f3e6c4; border-color: #f3e6c4; }
     .navbar-cta-count { font-size: 0.75rem; font-weight: 600; opacity: 0.7; margin-left: 0.1rem; }
 
     /* ─── Navbar search trigger ──────────────────────────────── */
@@ -411,7 +411,7 @@
       /* Pin to paperclip.ing dark palette regardless of page theme */
       --bg: #141413;
       --surface: #1F1D1A;
-      --ink-t: #FFFFFF;
+      --ink-t: #F3E6C4;
       --mono: #9A958A;
       --rule: #2F2C28;
       background: var(--bg);

--- a/site/styles.css
+++ b/site/styles.css
@@ -43,20 +43,20 @@
       --transition: 0.2s ease;
     }
 
-    /* ─── Dark theme — warm charcoal + manila cream ──────────── */
+    /* ─── Dark theme — warm charcoal + white text ────────────── */
     [data-theme="dark"] {
       --white:      #1f1d1a;            /* surface */
       --linen:      #141413;            /* page background — charcoal */
       --parchment:  #2a2724;            /* raised surface */
       --stone:      #2f2c28;            /* rule / border */
       --stone-dark: #3a3836;            /* border hover */
-      --ink:        #f3e6c4;            /* manila — primary text */
+      --ink:        #ffffff;            /* primary text */
       --graphite:   #9a958a;            /* secondary text (brand --text-2 dark) */
       --ash:        #8a8579;            /* muted text — raised from brand #6E6960 for WCAG AA (~5:1) since --ash is reused for normal-size text */
       --void:       #0d0d0d;
       --mint:       rgba(34,197,94,0.12);
     }
-    [data-theme="dark"] #article pre { background: #0d0d0d; color: #f3e6c4; }
+    [data-theme="dark"] #article pre { background: #0d0d0d; color: #ffffff; }
     [data-theme="dark"] #header { background: rgba(20,20,19,0.92); backdrop-filter: blur(8px); }
 
     html {
@@ -168,8 +168,8 @@
       transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
     }
     .navbar-cta:hover { background: var(--white); color: var(--ink); border-color: var(--ink); }
-    [data-theme="dark"] .navbar-cta { color: #141413; background: #f3e6c4; border-color: #f3e6c4; }
-    [data-theme="dark"] .navbar-cta:hover { background: transparent; color: #f3e6c4; border-color: #f3e6c4; }
+    [data-theme="dark"] .navbar-cta { color: #141413; background: #ffffff; border-color: #ffffff; }
+    [data-theme="dark"] .navbar-cta:hover { background: transparent; color: #ffffff; border-color: #ffffff; }
     .navbar-cta-count { font-size: 0.75rem; font-weight: 600; opacity: 0.7; margin-left: 0.1rem; }
 
     /* ─── Navbar search trigger ──────────────────────────────── */
@@ -411,7 +411,7 @@
       /* Pin to paperclip.ing dark palette regardless of page theme */
       --bg: #141413;
       --surface: #1F1D1A;
-      --ink-t: #F3E6C4;
+      --ink-t: #FFFFFF;
       --mono: #9A958A;
       --rule: #2F2C28;
       background: var(--bg);


### PR DESCRIPTION
## Summary

- Add a dedicated **Community Desktop App (unofficial)** guide covering installation, Local/Remote modes, server connections, updates, and troubleshooting.
- Clearly identify `aronprins/paperclip-desktop` as community-maintained, unofficial, and unsupported by the Paperclip team.
- Remove the desktop app as a primary installation/start path across the installation, update, quickstart, glossary, terminal setup, export/import, and overview docs.
- Register the new page under **How-to Guides → Deploy & Maintain** and retain small cross-links where desktop-specific guidance is useful.

## Verification

- `npm run docs:build` — passed on the final PR branch.
- `sync:lint-links` — previously passed across 162 files with no broken links.
- `sync:verify-nav` — previously passed with only two pre-existing orphan pages.
- `docs:test:static-routes` — previously passed.
- Verified the new route, sitemap entry, and cross-links in the built `.site` output.

Closes PAP-14693.
