### PR TITLE
Add documentation changelog page with reusable accordion

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -31,6 +31,155 @@ The docs track Paperclip's [calendar-versioned](https://github.com/paperclipai/p
 </div>
 </details>
 
+<details class="accordion">
+<summary>Docs for v2026.720.0 <span class="accordion-meta">July 20, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- [Tool Gateway API](api/tool-gateway.md) — the MCP Tool Gateway: applications and connections, catalog entries and risk levels, profiles/entries/bindings, the tool-access policy, named MCP gateways and tokens, the audit feed, and the Smoke Lab. Documents the `tools:*` permission keys and both experimental gates.
+- [Summary Slots API](api/summary-slots.md) — the built-in Summarizer and summary slots (slot addressing, generation, revisions, the `enableSummaries` gate).
+
+**Updated pages**
+
+- [Skills](../guides/org/skills.md) — Skill Studio (the three-pane authoring workspace, saved inputs, test runs, run templates, version history), nested skill folders, the My Skills view, importing skills from a project, and company skill forks.
+- [Local Agents (ACPX)](adapters/acpx-local.md) — reduced to a retired stub after the upstream adapter retirement; points at Claude Code / Codex / Gemini CLI and documents the automatic migration.
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.707.0 <span class="accordion-meta">July 7, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- [Ramp skill](../reference/skills/optional/finance/ramp.md) — the bundled Ramp finance skill.
+- Custom sandbox images — documented on [Sandbox Providers](adapters/sandbox-providers.md).
+
+**Updated pages**
+
+- [Work Timeline](../guides/day-to-day/work-timeline.md) — the work-timeline view.
+- [Secret Scopes](../administration/secret-scopes.md) — secret-scope content.
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.626.0 <span class="accordion-meta">June 26, 2026</span></summary>
+<div class="accordion-body">
+
+**Updated pages**
+
+- [Hermes Adapter](adapters/hermes.md) and [Hermes Gateway](adapters/hermes-gateway.md) — the two built-in Hermes adapters.
+- [Work Modes](../guides/day-to-day/work-modes.md) — the new "ask" work mode.
+- [Routines](../guides/projects-workflow/routines.md) — routine date variables.
+- [Plugin SDK](plugins/sdk.md) — the plugin target command; also task watchdogs and workspace file downloads.
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.618.0 <span class="accordion-meta">June 18, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- Novita Agent Sandbox provider (driver `novita`) — added to [Sandbox Providers](adapters/sandbox-providers.md).
+- The `paperclip-board` bundled skill — added to [Skills](../guides/org/skills.md).
+
+**Updated pages**
+
+- Adapters — [Codex](adapters/codex.md), [Gemini CLI](adapters/gemini-cli.md), [OpenCode](adapters/opencode.md), [Pi](adapters/pi.md), [OpenClaw Gateway](adapters/openclaw-gateway.md), plus Kubernetes on [Sandbox Providers](adapters/sandbox-providers.md).
+- [Agents API](api/agents.md), [Plugin SDK](plugins/sdk.md), and [Environment Variables](deploy/environment-variables.md) (`TRUST_PROXY` / OTEL).
+- Day-to-day guides — [Artifacts](../guides/day-to-day/artifacts.md), [Issues](../guides/day-to-day/issues.md), [Routines](../guides/projects-workflow/routines.md).
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.609.0 <span class="accordion-meta">June 9, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- [`token` CLI](cli/token.md) — the `token agent` / `token board` API-key commands.
+- [`connect` CLI](cli/connect.md) — the interactive `connect` setup wizard.
+- [Teams Catalog API](api/teams-catalog.md) — the teams catalog REST API.
+
+**Updated pages**
+
+- Release-stamped 49 pages to `v2026.609.0` and registered the three new pages in the nav.
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.529.0 <span class="accordion-meta">May 29, 2026</span></summary>
+<div class="accordion-body">
+
+**Updated pages**
+
+- [Claude Code Adapter](adapters/claude-code.md) — UI-driven live model discovery (`/v1/models` lookup via `ANTHROPIC_API_KEY`, 60s cache, built-in fallback, Bedrock IDs, refresh control).
+- [Workspaces](../guides/projects-workflow/workspaces.md) — reused-workspace environment consistency and finalize-gated dependent wakes.
+- Inherited nightly drafts: [Resource Memberships API](api/resource-memberships.md), document annotations, bundled plugins in the plugin manager, the skills CLI + catalog, and first-admin claim.
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.525.0 <span class="accordion-meta">May 25, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- Modal sandbox provider — added to [Sandbox Providers](adapters/sandbox-providers.md).
+- [Workspace Diff Viewer plugin](plugins/workspace-diff.md) — split/unified and working-tree/against-ref toggles, base-ref input, sticky toolbar.
+
+**Updated pages**
+
+- [Plugin SDK](plugins/sdk.md) — SDK surface audit plus the managed-resources concept.
+- [Routines](../guides/projects-workflow/routines.md) — the routine env runtime contract and secret-ref binding picker.
+- Added a troubleshooting note for a 401 after creating a new secret.
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.517.0 <span class="accordion-meta">May 17, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- [Grok Local Adapter](adapters/grok-local.md) — the `grok_local` adapter, wired into the Adapters overview and nav.
+
+**Updated pages**
+
+- [Issues](../guides/day-to-day/issues.md) and [Issues API](api/issues.md) — the locking workflow (lock/unlock, derived-document redirect) and Board-view scaling controls.
+- [Sandbox Providers](adapters/sandbox-providers.md) — Cloudflare reliability tuning notes.
+
+</div>
+</details>
+
+<details class="accordion">
+<summary>Docs for v2026.513.0 <span class="accordion-meta">May 13, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- [Develop a plugin locally](../how-to/develop-a-plugin-locally.md) — a walkthrough of `paperclipai plugin init`, local-path install, the dev watcher, and reload.
+- [Blocked Inbox](../guides/day-to-day/blocked-inbox.md) — the Blocked Inbox tab, chip variants, filters, sort, and triage.
+
+**Updated pages**
+
+- [Issues](../guides/day-to-day/issues.md) and [Issues API](api/issues.md) — recovery actions and walking through sub-issues.
+- [Claude Code Adapter](adapters/claude-code.md) — resuming a session's workspace.
+- [Plugin SDK](plugins/sdk.md) — worker entrypoint validation.
+- [Plugins (administration)](../administration/plugins.md) — developing plugins locally.
+
+</div>
+</details>
+
 ---
 
-_This changelog starts at v2026.722.0. Documentation changes made before this page existed aren't listed here — the [Paperclip releases page](https://github.com/paperclipai/paperclip/releases) covers the product history that predates it._
+_This changelog begins at v2026.513.0, the first release tracked in this repo. For the product's full feature and fix history, see the [Paperclip releases page](https://github.com/paperclipai/paperclip/releases)._

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,0 +1,36 @@
+---
+paperclip_version: v2026.722.0
+---
+
+# Documentation Changelog
+
+What changed in **these docs** — pages added, rewritten, or expanded — with each documentation update. This is a changelog for the documentation itself, not for Paperclip the product.
+
+The docs track Paperclip's [calendar-versioned](https://github.com/paperclipai/paperclip/releases) releases (`YYYY.MDD.P`), so each entry is tagged with the Paperclip release the docs were brought in line with. For the product's own release notes — the actual feature and fix history — see the [Paperclip releases page](https://github.com/paperclipai/paperclip/releases). To update your install, see [Update Paperclip](../how-to/update-paperclip.md).
+
+---
+
+<details class="accordion" open>
+<summary>Docs for v2026.722.0 <span class="accordion-meta">July 22, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- [Secret Folders](../administration/secret-folders.md) — organizing secrets into folders.
+- [Connections & Apps](../experimental/connections-apps.md) — experimental Connections v3 (Apps) foundation.
+
+**Updated pages**
+
+- [Secrets API](api/secrets.md) and [Agents API](api/agents.md) — documented run-bound agent secret access (`GET /api/agents/me/secrets/:key/value`).
+- [Local Agents (ACPX)](adapters/acpx-local.md) — native Windows execution (no Bash wrapper).
+- [Environment Variables](deploy/environment-variables.md) — `PAPERCLIP_*` binding pass-through and opt-outs.
+- [Codex Adapter](adapters/codex.md) — the narrower `CODEX_HOME` sandbox-sync allowlist.
+- [Plugin SDK](plugins/sdk.md) — environment-sync exports and the `onEnvironmentSyncIn` / `onEnvironmentSyncOut` hooks.
+- [`company` CLI](cli/company.md) — the `export --force` flag.
+
+</div>
+</details>
+
+---
+
+_This changelog starts at v2026.722.0. Documentation changes made before this page existed aren't listed here — the [Paperclip releases page](https://github.com/paperclipai/paperclip/releases) covers the product history that predates it._

--- a/site/app.js
+++ b/site/app.js
@@ -1273,9 +1273,10 @@ async function renderMarkdown(md) {
 }
 
 const ALLOWED_MARKDOWN_TAGS = new Set([
-  'A', 'BLOCKQUOTE', 'BR', 'BUTTON', 'CODE', 'DEL', 'DIV', 'EM', 'H1', 'H2',
-  'H3', 'H4', 'H5', 'H6', 'HR', 'IMG', 'LI', 'OL', 'P', 'PRE', 'SPAN',
-  'STRONG', 'TABLE', 'TBODY', 'TD', 'TH', 'THEAD', 'TR', 'UL',
+  'A', 'BLOCKQUOTE', 'BR', 'BUTTON', 'CODE', 'DEL', 'DETAILS', 'DIV', 'EM',
+  'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HR', 'IMG', 'LI', 'OL', 'P', 'PRE',
+  'SPAN', 'STRONG', 'SUMMARY', 'TABLE', 'TBODY', 'TD', 'TH', 'THEAD', 'TR',
+  'UL',
 ]);
 const DROP_MARKDOWN_TAGS = new Set([
   'IFRAME', 'MATH', 'META', 'OBJECT', 'SCRIPT', 'STYLE', 'SVG', 'TEMPLATE',
@@ -1287,6 +1288,7 @@ const GLOBAL_MARKDOWN_ATTRS = new Set([
 const TAG_MARKDOWN_ATTRS = {
   A: new Set(['href']),
   BUTTON: new Set(['type']),
+  DETAILS: new Set(['open']),
   CODE: new Set(['class']),
   IMG: new Set(['alt', 'height', 'loading', 'src', 'title', 'width']),
 };

--- a/site/content.json
+++ b/site/content.json
@@ -929,6 +929,18 @@
           "file": "../docs/reference/deploy/tailscale-private-access.md"
         }
       ]
+    },
+    {
+      "tier": "Reference",
+      "title": "Changelog",
+      "icon": "history",
+      "desc": "What changed in these docs — pages added, rewritten, or expanded — with each documentation update.",
+      "pages": [
+        {
+          "title": "Docs",
+          "file": "../docs/reference/changelog.md"
+        }
+      ]
     }
   ]
 }

--- a/site/styles.css
+++ b/site/styles.css
@@ -1127,6 +1127,49 @@
     [data-theme="dark"] .callout-danger .callout-icon,
     [data-theme="dark"] .callout-danger .callout-label { color: #f87171; }
 
+    /* Accordion — native <details>/<summary> disclosure */
+    details.accordion {
+      border: 1px solid var(--stone);
+      border-radius: var(--radius-sm);
+      background: var(--white);
+      margin-bottom: 12px;
+      overflow: hidden;
+    }
+    details.accordion + details.accordion { margin-top: -4px; }
+    details.accordion > summary {
+      list-style: none;
+      cursor: pointer;
+      padding: 13px 16px;
+      display: flex; align-items: center; gap: 10px;
+      font-family: var(--font-serif);
+      font-size: 15px; font-weight: 600; letter-spacing: -0.01em;
+      color: var(--ink);
+      user-select: none;
+      transition: background var(--transition);
+    }
+    details.accordion > summary::-webkit-details-marker { display: none; }
+    details.accordion > summary:hover { background: var(--parchment); }
+    details.accordion > summary::before {
+      content: "";
+      flex-shrink: 0;
+      width: 8px; height: 8px;
+      border-right: 2px solid var(--ash);
+      border-bottom: 2px solid var(--ash);
+      transform: rotate(-45deg);
+      transition: transform var(--transition);
+    }
+    details.accordion[open] > summary::before { transform: rotate(45deg); }
+    details.accordion[open] > summary { border-bottom: 1px solid var(--stone); }
+    details.accordion .accordion-meta {
+      margin-left: auto;
+      font-family: var(--font-body);
+      font-size: 12px; font-weight: 500;
+      color: var(--ash);
+    }
+    details.accordion > .accordion-body { padding: 4px 16px 8px; }
+    details.accordion > .accordion-body > :first-child { margin-top: 12px; }
+    details.accordion > .accordion-body > :last-child { margin-bottom: 4px; }
+
     /* Tabs */
     .tabs-container { margin-bottom: 24px; }
     .tabs-bar {


### PR DESCRIPTION
## What

Adds a **Changelog** category (Reference tier) with a **Docs** page that tracks what changed in *these docs* — pages added, rewritten, or expanded — per release. It's framed as a changelog for the documentation itself, not a mirror of Paperclip's product release notes (which it links out to).

Backfilled with the full documentation history: **10 releases** from `v2026.513.0` (this repo's genesis) through `v2026.722.0`, reconstructed from each release commit's own docs summary. Each release is a collapsible accordion; the newest stays open.

## New design-system component

Introduces a reusable native `<details>`/`<summary>` **accordion** (no JS):

- `site/styles.css` — `details.accordion` styled with existing tokens (border/radius, parchment hover, rotating chevron, theme-aware), with an optional `.accordion-meta` right-aligned label.
- `site/app.js` — allowlists `DETAILS`/`SUMMARY` + the `open` attribute in the client-side markdown sanitizer so collapsible content survives SPA rendering.

Usage:

```html
<details class="accordion" open>
<summary>Title <span class="accordion-meta">meta</span></summary>
<div class="accordion-body">

Markdown content — keep the blank lines so it parses.

</div>
</details>
```

## Files

- `docs/reference/changelog.md` (new)
- `site/content.json` — Changelog category / Docs page nav entry
- `site/styles.css`, `site/app.js` — accordion component

## Verification

- `npm run sync:lint-links` — clean, no broken internal links (links verified against current tree; renamed/retired pages point at live targets).
- `npm run sync:verify-nav` — passes (only orphans are the intentional CLI redirect pages).
- `npm run docs:build` — all 10 accordions render, `/reference/changelog/` route builds.

## Note

This is a **manual** changelog for now. A follow-up could hook a "prepend a new accordion" step into the `/sync-docs` release phase so future releases self-populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)