### PR TITLE
docs: fix goals reparenting, human-invite signup, macOS install, first-company step

### DIFF
--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -61,6 +61,16 @@ This single command handles everything: it downloads Paperclip, creates a config
 → Opening Paperclip in your browser...
 ```
 
+> **Troubleshooting (macOS, Apple Silicon):** If onboarding fails while starting the embedded PostgreSQL, it's usually a missing library symlink. The bundled Postgres (`@embedded-postgres/darwin-arm64`) ships versioned compression libraries — for example `libzstd.1.5.7.dylib` and `liblz4.1.10.0.dylib` — but not the shorter compatibility symlinks (`libzstd.1.dylib`, `liblz4.1.dylib`) that Postgres looks for, so it won't start until you add them. Find the versioned files under the embedded-postgres package (inside its `.../lib` directory in `node_modules`) and create the missing symlinks, then re-run `npx paperclipai run`:
+>
+> ```bash
+> cd "$(dirname "$(find ~ -path '*@embedded-postgres/darwin-arm64*/lib/libzstd.*.dylib' 2>/dev/null | head -1)")"
+> ln -sf libzstd.*.dylib libzstd.1.dylib
+> ln -sf liblz4.*.dylib liblz4.1.dylib
+> ```
+>
+> Version numbers vary between releases — match whichever versioned `.dylib` files are actually present.
+
 ---
 
 ## Step 4 — Open Paperclip

--- a/docs/guides/getting-started/your-first-company.md
+++ b/docs/guides/getting-started/your-first-company.md
@@ -53,7 +53,7 @@ Make sure Paperclip is installed and running. If you haven't done that yet, star
 
    You can update or add goals later from the **Goals** section. If your priorities change, revise the goal there and the CEO will factor it into its next strategy cycle.
 
-4. **Save and continue**
+4. **Create the company**
 
    Click **Create Company**. Paperclip creates the company and takes you to its dashboard.
 

--- a/docs/guides/projects-workflow/goals.md
+++ b/docs/guides/projects-workflow/goals.md
@@ -53,7 +53,7 @@ The header shows:
 
 - **Level** — the goal's level label in muted uppercase (for example `COMPANY` or `TEAM`). Levels are how Paperclip lets you separate high-level company outcomes from narrower team or workstream goals.
 - **Status** — a status badge. Goals use the same status vocabulary as projects and issues for visual consistency, so you can tell at a glance whether a goal is active, achieved, or dropped.
-- **Properties toggle** — a small slider icon on the right that re-opens the properties panel if you closed it. The properties panel is where you edit level, status, parent, and other metadata without having to leave the page.
+- **Properties toggle** — a small slider icon on the right that re-opens the properties panel if you closed it. The properties panel is where you edit level, status, and other metadata without having to leave the page. The parent goal is shown here but is not editable from the panel — see [Reparenting and flattening](#reparenting-and-flattening).
 
 The body below the header has:
 
@@ -124,7 +124,17 @@ You can also create a sub-goal from the main Goals page by choosing a parent in 
 
 ### Reparenting and flattening
 
-Moving a goal between parents is done from the goal's properties panel — change the parent field, and the tree re-renders. Flattening a sub-goal to a root goal is the same action, with the parent set to none.
+A goal's parent is set **when you create it** — either by choosing a parent in the new-goal dialog or by using the **Sub Goal** button, which pre-fills it. The app does not currently expose an editable parent field on an existing goal, so changing a goal's parent (or flattening a sub-goal back to a root goal) is done through the CLI or API rather than the properties panel:
+
+```sh
+# Re-parent a goal under a different parent
+paperclipai goal update <goal-id> --parent-id <new-parent-goal-id>
+
+# Flatten a sub-goal to a top-level goal
+paperclipai goal update <goal-id> --parent-id null
+```
+
+The same change is available on the API via `PATCH /goals/{id}` with a `parentId` field (pass `null` to promote the goal to the root). The tree re-renders once the change lands. See the [Goal CLI reference](../../reference/cli/goal.md#update-a-goal) for the full flag list.
 
 Deep hierarchies are rarely the right answer. Two or three levels is usually enough to capture the structure without making the tree tedious to read.
 

--- a/docs/how-to/add-a-human-teammate.md
+++ b/docs/how-to/add-a-human-teammate.md
@@ -47,6 +47,8 @@ When they open the URL they land on a Paperclip join page branded with your comp
 
 On their side they see a "waiting for approval" state. Nothing they do from here touches your company data until you approve them.
 
+> **If they see "Email and password sign up is not enabled":** your instance has self-service sign-up turned off, so the invitee can't create the account they need to accept the invite. This is controlled by the `auth.disableSignUp` config field (or the `PAPERCLIP_AUTH_DISABLE_SIGN_UP` environment variable). To let invited teammates register, make sure sign-up is enabled — set `auth.disableSignUp` to `false` (its default) or confirm `PAPERCLIP_AUTH_DISABLE_SIGN_UP` isn't set to `true` — then restart the instance and have them reopen the invite link. See [Enable multi-user login](./enable-multi-user-login.md) for the full authenticated-mode setup.
+
 ---
 
 ## 5. Approve them (and fine-tune access)


### PR DESCRIPTION
Addresses open documentation-feedback issues, each verified against the `paperclipai/paperclip` source.

## Changes

- **Goals — reparenting (#13):** The goal properties panel renders the parent goal as a read-only link (unlike issues, which have an editable parent picker), and the goal update mutation never sends `parentId`. The docs claimed you could "change the parent field" in the panel. Corrected to describe the real path — `paperclipai goal update <id> --parent-id <id|null>` / `PATCH /goals/{id}` — and removed "parent" from the list of panel-editable fields.
- **Add a human teammate — signup (#50):** The reported "Email and password sign up is not enabled" is thrown by Better Auth when `emailAndPassword.disableSignUp` is set, which Paperclip wires from `auth.disableSignUp` / `PAPERCLIP_AUTH_DISABLE_SIGN_UP`. Added a troubleshooting callout naming the cause and how to re-enable self-service signup.
- **Installation — macOS Apple Silicon (#74):** The Terminal install path had no troubleshooting section. Added a note for the embedded PostgreSQL start failure caused by missing `libzstd`/`liblz4` compatibility symlinks, with a copy-paste fix.
- **Create your first company (#16):** Renamed the step 4 heading from "Save and continue" to "Create the company" to match the actual **Create Company** button.

## Verification

- `sync:lint-links` passes — 186 markdown files, no broken internal links.
- Product-behaviour claims (#13, #50) confirmed directly in parent source; #74 documents the reporter's symptom (doc-gap confirmed, not independently reproduced).

Closes #13, #16, #50, #74