### PR TITLE
Render full SKILL.md as a code snippet on per-skill pages (PAP-16980)

### DIFF
--- a/docs/reference/skills/bundled/docs/doc-maintenance.md
+++ b/docs/reference/skills/bundled/docs/doc-maintenance.md
@@ -51,21 +51,23 @@ This is a **bundled** catalog skill — part of the bundled baseline kit. For ho
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** doc-maintenance
-- **description:** Keep project docs aligned with recent code and feature changes — detect drift, update affected pages, and add release-relevant notes without rewriting unchanged sections.
-- **key:** paperclipai/bundled/docs/doc-maintenance
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: doc-maintenance
+description: Keep project docs aligned with recent code and feature changes — detect drift, update affected pages, and add release-relevant notes without rewriting unchanged sections.
+key: paperclipai/bundled/docs/doc-maintenance
+recommendedForRoles:
   - engineer
   - product
   - devrel
-- **tags:**
+tags:
   - docs
   - documentation
   - release-notes
+---
 
-### Skill instructions
 # Doc Maintenance
 
 Keep the documentation honest with minimum churn. The goal is alignment between docs and behavior, not stylistic rewrites or cosmetic re-organization. Reviewers should be able to read a diff and see "this updates docs to match recent behavior changes".
@@ -127,6 +129,7 @@ When you find drift, fix it in the same pass and note it in the release note's `
 - "Updated docs" commit messages with no detail. Make the commit say what changed and why.
 - Adding to the changelog without updating the reference docs the changelog points to.
 - Marking a feature as available before its code lands. Documentation must follow behavior, not promise it.
+````
 
 ## See also
 

--- a/docs/reference/skills/bundled/paperclip-operations/issue-triage.md
+++ b/docs/reference/skills/bundled/paperclip-operations/issue-triage.md
@@ -51,22 +51,24 @@ This is a **bundled** catalog skill — part of the bundled baseline kit. For ho
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** issue-triage
-- **description:** Triage Paperclip inbox issues that are stale, blocked, in-review, or assigned-but-not-progressing, and decide a single next action per issue (resume, reassign, unblock, escalate, or close).
-- **key:** paperclipai/bundled/paperclip-operations/issue-triage
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: issue-triage
+description: Triage Paperclip inbox issues that are stale, blocked, in-review, or assigned-but-not-progressing, and decide a single next action per issue (resume, reassign, unblock, escalate, or close).
+key: paperclipai/bundled/paperclip-operations/issue-triage
+recommendedForRoles:
   - manager
   - ceo
   - engineer
-- **tags:**
+tags:
   - paperclip
   - triage
   - inbox
   - workflow
+---
 
-### Skill instructions
 # Issue Triage
 
 Convert a noisy inbox into a small set of clear next actions. Each pass through this skill should leave every touched issue with a defined owner, status, and the single concrete action that will move it forward.
@@ -126,6 +128,7 @@ A short comment chain or summary message that lists, per issue touched:
 - The one action you took or asked for.
 
 This is the bar for "the triage is done."
+````
 
 ## See also
 

--- a/docs/reference/skills/bundled/paperclip-operations/task-planning.md
+++ b/docs/reference/skills/bundled/paperclip-operations/task-planning.md
@@ -52,22 +52,24 @@ This is a **bundled** catalog skill — part of the bundled baseline kit. For ho
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** task-planning
-- **description:** Turn a Paperclip issue or request into a structured implementation plan with child task graph, blockers, owners, and acceptance criteria, then save it as the issue `plan` document.
-- **key:** paperclipai/bundled/paperclip-operations/task-planning
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: task-planning
+description: Turn a Paperclip issue or request into a structured implementation plan with child task graph, blockers, owners, and acceptance criteria, then save it as the issue `plan` document.
+key: paperclipai/bundled/paperclip-operations/task-planning
+recommendedForRoles:
   - manager
   - engineer
   - product
-- **tags:**
+tags:
   - paperclip
   - planning
   - issues
   - delegation
+---
 
-### Skill instructions
 # Task Planning
 
 Produce implementation plans that the Paperclip executor can actually run: explicit child issues, real blockers, named owners, and a defined acceptance bar. Avoid plans that read well but cannot be split into work.
@@ -137,6 +139,7 @@ When the plan is accepted, see the companion skill for converting accepted plans
 - Children with descriptions that say "see parent" — they fail at delegation time.
 - Acceptance written as "code review approval". Reviewers need a behavior bar, not a process bar.
 - Plans that bury blocker chains in prose. Use explicit blocked-by lines.
+````
 
 ## See also
 

--- a/docs/reference/skills/bundled/product/wireframe.md
+++ b/docs/reference/skills/bundled/product/wireframe.md
@@ -56,23 +56,25 @@ This is a **bundled** catalog skill — part of the bundled baseline kit. For ho
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** wireframe
-- **description:** Produce low-fidelity black-and-white UI wireframes as standalone SVG files, optionally bundled into a single-page HTML viewer and published via the here-now skill. Use when the user asks to "wireframe X", "sketch a screen for", "draft a layout", "low-fi mockup", "rough mock", "make a page to view the wireframes", "build a viewer for these screens", or to "deploy / publish / host the wireframes". Do NOT use when the user wants production UI code, branded designs, hi-fi mockups, or animated/interactive prototypes — use frontend-design or similar instead.
-- **key:** paperclipai/bundled/product/wireframe
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: wireframe
+description: Produce low-fidelity black-and-white UI wireframes as standalone SVG files, optionally bundled into a single-page HTML viewer and published via the here-now skill. Use when the user asks to "wireframe X", "sketch a screen for", "draft a layout", "low-fi mockup", "rough mock", "make a page to view the wireframes", "build a viewer for these screens", or to "deploy / publish / host the wireframes". Do NOT use when the user wants production UI code, branded designs, hi-fi mockups, or animated/interactive prototypes — use frontend-design or similar instead.
+key: paperclipai/bundled/product/wireframe
+recommendedForRoles:
   - designer
   - product
   - engineer
-- **tags:**
+tags:
   - design
   - wireframe
   - ux
   - prototyping
   - svg
+---
 
-### Skill instructions
 # Wireframe
 
 Produce low-fidelity, black-and-white UI wireframes as **standalone SVG files**. The goal is to communicate **structure** — what goes where, in what order, at roughly what size — without committing to colour, brand, or polish.
@@ -250,6 +252,7 @@ Things to remember when invoking it:
 - `assets/template.svg` — blank desktop canvas with hidden 8px-grid guides; copy as a starting point.
 - `assets/template-mobile.svg` — same for 375×812 mobile.
 - `assets/site-template.html` — minimal review-viewer page (sticky TOC + responsive collapse + lightbox). Copy to `design/<task-slug>/index.html` and fill in the sections when the user requests a website.
+````
 
 ## See also
 

--- a/docs/reference/skills/bundled/quality/qa-acceptance.md
+++ b/docs/reference/skills/bundled/quality/qa-acceptance.md
@@ -51,22 +51,24 @@ This is a **bundled** catalog skill — part of the bundled baseline kit. For ho
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** qa-acceptance
-- **description:** Produce QA acceptance criteria and a manual validation plan for a feature change — golden path, edge cases, error states, performance limits, and explicit pass/fail evidence.
-- **key:** paperclipai/bundled/quality/qa-acceptance
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: qa-acceptance
+description: Produce QA acceptance criteria and a manual validation plan for a feature change — golden path, edge cases, error states, performance limits, and explicit pass/fail evidence.
+key: paperclipai/bundled/quality/qa-acceptance
+recommendedForRoles:
   - qa
   - engineer
   - product
-- **tags:**
+tags:
   - qa
   - acceptance
   - validation
   - testing
+---
 
-### Skill instructions
 # QA Acceptance
 
 Write acceptance criteria that a reviewer can run against the running app and decide pass or fail without asking the author. The criteria are the contract — automated tests cover correctness, QA covers feature-level behavior.
@@ -145,6 +147,7 @@ The author owns turning failures into either fixes or accepted deferrals.
 - Criteria that depend on inspecting implementation details (selectors, query plans). Stay observable.
 - Long checklists with no priority. Mark must-pass criteria distinctly from nice-to-have.
 - Validation reports that say "passed" with no evidence. Reviewers cannot audit those.
+````
 
 ## See also
 

--- a/docs/reference/skills/bundled/software-development/github-pr-workflow.md
+++ b/docs/reference/skills/bundled/software-development/github-pr-workflow.md
@@ -50,20 +50,22 @@ This is a **bundled** catalog skill — part of the bundled baseline kit. For ho
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** github-pr-workflow
-- **description:** Prepare a GitHub pull request from a feature branch — branch hygiene, commit shape, title/body, verification notes, screenshots for UI work, and replies to review comments.
-- **key:** paperclipai/bundled/software-development/github-pr-workflow
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: github-pr-workflow
+description: Prepare a GitHub pull request from a feature branch — branch hygiene, commit shape, title/body, verification notes, screenshots for UI work, and replies to review comments.
+key: paperclipai/bundled/software-development/github-pr-workflow
+recommendedForRoles:
   - engineer
-- **tags:**
+tags:
   - github
   - pull-requests
   - code-review
   - release
+---
 
-### Skill instructions
 # GitHub Pull Request Workflow
 
 Ship a PR a reviewer can land without follow-up clarifying questions. The aim is high signal in the title and body, evidence the change works, and clean replies when feedback comes in.
@@ -144,6 +146,7 @@ Skip the `Risk and rollback` section only for clearly trivial PRs (typos, docs).
 - Mixing refactor and behavior change in the same PR with no separation in the body.
 - "Address feedback" commits that bundle unrelated edits. One commit per round of feedback is fine; one commit for everything in flight is not.
 - Force-pushing during active review without telling the reviewer.
+````
 
 ## See also
 

--- a/docs/reference/skills/optional/browser/agent-browser.md
+++ b/docs/reference/skills/optional/browser/agent-browser.md
@@ -52,22 +52,24 @@ This is an **optional** catalog skill — opt-in (install when you need it). For
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** agent-browser
-- **description:** Drive a real browser to inspect or interact with a web page or app — navigate, take screenshots, read console and network, fill simple forms — for verification tasks, not unattended automation.
-- **key:** paperclipai/optional/browser/agent-browser
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: agent-browser
+description: Drive a real browser to inspect or interact with a web page or app — navigate, take screenshots, read console and network, fill simple forms — for verification tasks, not unattended automation.
+key: paperclipai/optional/browser/agent-browser
+recommendedForRoles:
   - qa
   - engineer
   - researcher
-- **tags:**
+tags:
   - browser
   - puppeteer
   - playwright
   - verification
+---
 
-### Skill instructions
 # Agent Browser
 
 Use a controlled browser to verify behavior, capture evidence, or extract information from web pages that a static fetch cannot reach (SPAs, login-gated pages, dynamic content). This skill is about supervised verification, not unattended scraping.
@@ -146,6 +148,7 @@ For a UI bug repro, also record:
 - Scraping behind authentication you do not own.
 - Captioning a screenshot with "looks good" without saying what state was loaded and what selectors confirmed it.
 - Treating a passing screenshot as proof of correctness across viewports you did not actually test.
+````
 
 ## See also
 

--- a/docs/reference/skills/optional/content/release-announcement.md
+++ b/docs/reference/skills/optional/content/release-announcement.md
@@ -50,22 +50,24 @@ This is an **optional** catalog skill — opt-in (install when you need it). For
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** release-announcement
-- **description:** Write a release announcement — changelog, blog post, in-app note, or social post — that leads with user impact, names the audience, and includes upgrade/migration steps without filler.
-- **key:** paperclipai/optional/content/release-announcement
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: release-announcement
+description: Write a release announcement — changelog, blog post, in-app note, or social post — that leads with user impact, names the audience, and includes upgrade/migration steps without filler.
+key: paperclipai/optional/content/release-announcement
+recommendedForRoles:
   - devrel
   - product
   - writer
-- **tags:**
+tags:
   - release
   - changelog
   - announcement
   - communication
+---
 
-### Skill instructions
 # Release Announcement
 
 Write the channel-appropriate announcement for a release without churn. Different surfaces need different shapes: a changelog entry is not a blog post is not a social card. The bar is: a reader of the chosen surface can decide in under 30 seconds whether this release affects them, and if so what to do.
@@ -179,6 +181,7 @@ Same as changelog, plus:
 - All links work (release tag, PRs, docs sections).
 - Breaking changes are also in the upgrade guide, not only the post.
 - Internal team is notified before the public post goes live, not after.
+````
 
 ## See also
 

--- a/docs/reference/skills/optional/product/design-critique.md
+++ b/docs/reference/skills/optional/product/design-critique.md
@@ -51,22 +51,24 @@ This is an **optional** catalog skill — opt-in (install when you need it). For
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** design-critique
-- **description:** Give a structured product design critique — user job clarity, hierarchy, affordance, error states, accessibility, and consistency — focused on what to change, in what order, and why.
-- **key:** paperclipai/optional/product/design-critique
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: design-critique
+description: Give a structured product design critique — user job clarity, hierarchy, affordance, error states, accessibility, and consistency — focused on what to change, in what order, and why.
+key: paperclipai/optional/product/design-critique
+recommendedForRoles:
   - designer
   - product
   - engineer
-- **tags:**
+tags:
   - design
   - product
   - ux
   - review
+---
 
-### Skill instructions
 # Product Design Critique
 
 A structured critique pass for a screen, flow, or component. The output is a prioritized list of changes a designer or engineer can act on — not adjectives. Critique is not redesign; recommend, do not rebuild.
@@ -173,6 +175,7 @@ Always include the "strengths to keep" section. It is not flattery — it is sig
 - Suggesting net-new features under the guise of a critique.
 - Ignoring user context and grading on taste.
 - Treating a critique as approval. State approval explicitly if asked; otherwise critique is feedback, not sign-off.
+````
 
 ## See also
 

--- a/docs/reference/skills/optional/research/last30days.md
+++ b/docs/reference/skills/optional/research/last30days.md
@@ -53,24 +53,26 @@ Only `SKILL.md` is reproduced below. The supporting scripts, library modules, an
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** last30days
-- **version:** "3.3.0"
-- **description:** "Research what people actually say about any topic in the last 30 days. Pulls posts and engagement from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web."
-- **argument-hint:** 'last30days nvidia earnings reaction | last30days AI video tools | last30days what users want in react'
-- **allowed-tools:** Bash, Read, Write, AskUserQuestion, WebSearch
-- **homepage:** https://github.com/mvanhorn/last30days-skill
-- **repository:** https://github.com/mvanhorn/last30days-skill
-- **author:** mvanhorn
-- **license:** MIT
-- **user-invocable:** true
-- **metadata:**
-  - **openclaw:**
-    - **emoji:** "📰"
-    - **requires:**
-      - **env:** []
-      - **optionalEnv:**
+````markdown skill-source
+---
+name: last30days
+version: "3.3.0"
+description: "Research what people actually say about any topic in the last 30 days. Pulls posts and engagement from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web."
+argument-hint: 'last30days nvidia earnings reaction | last30days AI video tools | last30days what users want in react'
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+homepage: https://github.com/mvanhorn/last30days-skill
+repository: https://github.com/mvanhorn/last30days-skill
+author: mvanhorn
+license: MIT
+user-invocable: true
+metadata:
+  openclaw:
+    emoji: "📰"
+    requires:
+      env: []
+      optionalEnv:
         - SCRAPECREATORS_API_KEY
         - OPENAI_API_KEY
         - XAI_API_KEY
@@ -83,14 +85,14 @@ Only `SKILL.md` is reproduced below. The supporting scripts, library modules, an
         - BSKY_HANDLE
         - BSKY_APP_PASSWORD
         - TRUTHSOCIAL_TOKEN
-      - **bins:**
+      bins:
         - node
         - python3
-    - **primaryEnv:** SCRAPECREATORS_API_KEY
-    - **files:**
+    primaryEnv: SCRAPECREATORS_API_KEY
+    files:
       - "scripts/*"
-    - **homepage:** https://github.com/mvanhorn/last30days-skill
-    - **tags:**
+    homepage: https://github.com/mvanhorn/last30days-skill
+    tags:
       - research
       - deep-research
       - reddit
@@ -114,8 +116,8 @@ Only `SKILL.md` is reproduced below. The supporting scripts, library modules, an
       - web-search
       - ai-skill
       - clawhub
+---
 
-### Skill instructions
 # STEP 0: STALE-CLONE SELF-CHECK — RUN BEFORE READING BELOW
 
 Before reading anything else in this file, check whether you loaded SKILL.md from the one known stale-clone location: Claude Code's marketplaces directory.
@@ -1763,6 +1765,7 @@ Want another prompt? Just tell me what you're creating next.
 **Bundled scripts:** `scripts/last30days.py` (main research engine), `scripts/lib/` (search, enrichment, rendering modules), `scripts/lib/vendor/bird-search/` (vendored X search client, MIT licensed)
 
 Review scripts before first use to verify behavior.
+````
 
 ## See also
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "docs:test:static-routes": "node scripts/verify-static-routes.mjs",
     "docs:test:asset-fingerprints": "node scripts/verify-asset-fingerprints.mjs",
     "docs:test:hierarchical-skills-nav": "node scripts/verify-hierarchical-skills-nav.mjs",
+    "docs:test:skill-source-blocks": "node scripts/verify-skill-source-blocks.mjs",
     "docs:serve": "python3 -m http.server 4321 --directory .site",
     "sync:lint-links": "node scripts/sync/lint-links.mjs",
     "sync:verify-nav": "node scripts/sync/verify-nav.mjs",

--- a/scripts/verify-skill-source-blocks.mjs
+++ b/scripts/verify-skill-source-blocks.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+// Verifies the per-skill reference pages render their authoritative SKILL.md as
+// a single markdown code block that reuses the production code-snippet treatment
+// and exposes a Download control, without disturbing any other code snippet.
+//
+// Contract checked here (see PAP-16980):
+//   * Every per-skill page with a "## Full skill definition" section embeds the
+//     complete SKILL.md inside a fenced ```` ```markdown skill-source ```` block.
+//   * That block renders to <pre><code class="language-markdown"
+//     data-skill-download="SKILL.md"> in the crawler-visible HTML.
+//   * The full source is a single code block (inner ``` fences stay literal).
+//   * The page keeps exactly one H1, and the old parsed-markdown
+//     "### Skill frontmatter" / "### Skill instructions" layout is gone.
+//   * Ordinary code snippets are untouched (no stray Download affordance).
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseFrontmatter, renderStaticMarkdown } from "../site/build-release.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, "..");
+const skillsRoot = path.join(root, "docs", "reference", "skills");
+
+const CODE_OPEN = '<pre><code class="language-markdown" data-skill-download="SKILL.md">';
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "screenshots") continue;
+      files.push(...(await walk(full)));
+    } else if (entry.name.endsWith(".md")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function fenceBlocks(markdown) {
+  // Match fenced blocks of >= 3 backticks whose info string carries the
+  // `skill-source` marker, closed by a fence of at least the same length.
+  const re = /(^|\n)(`{3,})([^\n]*)\n([\s\S]*?)\n\2`*(?=\n|$)/g;
+  const blocks = [];
+  let m;
+  while ((m = re.exec(markdown)) !== null) {
+    const info = m[3].trim().split(/\s+/);
+    if (info.includes("skill-source")) blocks.push({ info: m[3].trim(), body: m[4] });
+  }
+  return blocks;
+}
+
+let checkedSkillPages = 0;
+let checkedControlBlocks = 0;
+const failures = [];
+
+const files = await walk(skillsRoot);
+for (const file of files) {
+  const rel = path.relative(root, file);
+  const raw = await fs.readFile(file, "utf8");
+  const { body } = parseFrontmatter(raw);
+
+  if (!/^## Full skill definition$/m.test(body)) continue; // index pages / ramp-style summaries
+  checkedSkillPages += 1;
+
+  try {
+    const blocks = fenceBlocks(body);
+    assert.equal(blocks.length, 1, `expected exactly one skill-source block, found ${blocks.length}`);
+    const block = blocks[0];
+    assert.match(block.info, /^markdown\b/, `skill-source fence should be tagged "markdown", got "${block.info}"`);
+    assert.match(block.body, /^---\n/, "embedded SKILL.md should begin with YAML frontmatter");
+    assert.match(block.body, /\nname:\s*\S/, "embedded SKILL.md frontmatter should carry a name");
+
+    // The legacy parsed-markdown layout must be gone.
+    assert.doesNotMatch(body, /^### Skill frontmatter$/m, "leftover '### Skill frontmatter' heading");
+    assert.doesNotMatch(body, /^### Skill instructions$/m, "leftover '### Skill instructions' heading");
+
+    const html = renderStaticMarkdown(body);
+    const h1Count = (html.match(/<h1\b/g) || []).length;
+    assert.equal(h1Count, 1, `page should render a single H1, found ${h1Count}`);
+
+    const open = html.indexOf(CODE_OPEN);
+    assert.notEqual(open, -1, `rendered HTML missing ${CODE_OPEN}`);
+    // The whole SKILL.md — including its own ``` fences — must collapse into a
+    // single code block; a breakout would produce extra <pre>/<code> elements.
+    assert.equal((html.match(/<pre>/g) || []).length, 1, "skill source must render as exactly one <pre>");
+    assert.equal((html.match(/data-skill-download="SKILL.md"/g) || []).length, 1, "exactly one downloadable skill block");
+    const close = html.indexOf("</code></pre>", open);
+    const segment = html.slice(open, close);
+    assert.ok(segment.includes("name:"), "rendered skill source should include frontmatter");
+    // The Given/when/then and fenced snippets inside SKILL.md must be escaped, not re-parsed.
+    assert.ok(!segment.includes("<h2"), "SKILL.md headings must stay literal inside the code block");
+  } catch (error) {
+    failures.push(`${rel}: ${error.message}`);
+  }
+}
+
+// A control page with an ordinary code fence must not gain a Download affordance.
+const controlPath = path.join(root, "docs", "how-to", "write-a-company-skill.md");
+try {
+  const control = await fs.readFile(controlPath, "utf8");
+  const { body } = parseFrontmatter(control);
+  const html = renderStaticMarkdown(body);
+  checkedControlBlocks += 1;
+  assert.ok(!html.includes("data-skill-download"), "ordinary docs pages must not emit data-skill-download");
+} catch (error) {
+  failures.push(`write-a-company-skill.md (control): ${error.message}`);
+}
+
+// Full skill source is prose-heavy and can contain very long argument hints,
+// URLs, and examples. It should preserve source line breaks while wrapping
+// within the viewport; ordinary code blocks retain horizontal scrolling.
+try {
+  const styles = await fs.readFile(path.join(root, "site", "styles.css"), "utf8");
+  const skillRule = styles.match(/#article pre code\[data-skill-download="SKILL\.md"\]\s*\{([\s\S]*?)\}/);
+  assert.ok(skillRule, "missing skill-source-specific wrapping rule");
+  assert.match(skillRule[1], /white-space:\s*pre-wrap/, "skill source must preserve line breaks while wrapping");
+  assert.match(skillRule[1], /overflow-wrap:\s*anywhere/, "skill source must wrap long unbroken values");
+} catch (error) {
+  failures.push(`site/styles.css (skill source wrapping): ${error.message}`);
+}
+
+if (failures.length) {
+  console.error("Skill source block verification FAILED:\n" + failures.map((f) => `  - ${f}`).join("\n"));
+  process.exit(1);
+}
+
+assert.ok(checkedSkillPages >= 10, `expected at least 10 per-skill pages, checked ${checkedSkillPages}`);
+console.log(`Skill source block verification passed (${checkedSkillPages} skill pages, ${checkedControlBlocks} control page).`);

--- a/site/app.js
+++ b/site/app.js
@@ -419,6 +419,7 @@ function decorateHeadings(article, file) {
 function decorateCodeBlocks(article) {
   const COPY_SVG = '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M3 11V3a1 1 0 0 1 1-1h7"/></svg>';
   const CHECK_SVG = '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m3 8 3.5 3.5L13 5"/></svg>';
+  const DOWNLOAD_SVG = '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v8"/><path d="M4.5 7 8 10.5 11.5 7"/><path d="M3 13h10"/></svg>';
   article.querySelectorAll('pre').forEach(pre => {
     if (pre.parentElement?.classList.contains('code-wrap')) return;
     const wrap = document.createElement('div');
@@ -444,6 +445,40 @@ function decorateCodeBlocks(article) {
       } catch {}
     });
     wrap.appendChild(btn);
+
+    // Blocks that advertise a downloadable filename (the authoritative skill
+    // source) get a Download control beside Copy, sharing its dimensions,
+    // styling, and hover/focus visibility (see .code-download in styles.css).
+    const downloadable = pre.querySelector('code[data-skill-download]');
+    const filename = downloadable?.getAttribute('data-skill-download');
+    if (downloadable && filename) {
+      const dl = document.createElement('button');
+      dl.className = 'code-download';
+      dl.type = 'button';
+      dl.setAttribute('aria-label', `Download ${filename}`);
+      dl.title = `Download ${filename}`;
+      dl.innerHTML = DOWNLOAD_SVG;
+      dl.addEventListener('click', () => {
+        try {
+          const blob = new Blob([downloadable.textContent], { type: 'text/markdown' });
+          const url = URL.createObjectURL(blob);
+          const anchor = document.createElement('a');
+          anchor.href = url;
+          anchor.download = filename;
+          document.body.appendChild(anchor);
+          anchor.click();
+          anchor.remove();
+          setTimeout(() => URL.revokeObjectURL(url), 0);
+          dl.classList.add('is-copied');
+          dl.innerHTML = CHECK_SVG;
+          setTimeout(() => {
+            dl.classList.remove('is-copied');
+            dl.innerHTML = DOWNLOAD_SVG;
+          }, 1200);
+        } catch {}
+      });
+      wrap.appendChild(dl);
+    }
   });
 }
 
@@ -1293,9 +1328,31 @@ function stripFrontmatter(md) {
   return rest.slice(closeMatch.index + closeMatch[0].length).replace(/^\r?\n/, '');
 }
 
+let skillAwareRenderer = null;
+// Mirror of the release build's code renderer (site/build-release.mjs): a fenced
+// block tagged `skill-source` renders as a standard markdown code block that also
+// advertises a downloadable filename via `data-skill-download`. Every other code
+// block is delegated to marked's default renderer, so existing snippets are
+// untouched. Keeping this in sync with the build keeps the Download control
+// available on SPA navigation as well as on the crawler-visible first render.
+function getSkillAwareRenderer(marked) {
+  if (skillAwareRenderer) return skillAwareRenderer;
+  const renderer = new marked.Renderer();
+  const defaultCode = renderer.code.bind(renderer);
+  renderer.code = (code, infostring, escaped) => {
+    const tokens = String(infostring || '').trim().split(/\s+/);
+    if (tokens.includes('skill-source')) {
+      return `<pre><code class="language-markdown" data-skill-download="SKILL.md">${escapeHtml(code)}\n</code></pre>\n`;
+    }
+    return defaultCode(code, infostring, escaped);
+  };
+  skillAwareRenderer = renderer;
+  return renderer;
+}
+
 async function renderMarkdown(md) {
   const renderer = await ensureMarkdownRenderer();
-  renderer.setOptions({ gfm: true, breaks: false });
+  renderer.setOptions({ gfm: true, breaks: false, renderer: getSkillAwareRenderer(renderer) });
   md = stripFrontmatter(md);
   md = preprocessTabs(md);
   return sanitizeMarkdownHtml(renderer.parse(md));
@@ -1318,7 +1375,7 @@ const TAG_MARKDOWN_ATTRS = {
   A: new Set(['href']),
   BUTTON: new Set(['type']),
   DETAILS: new Set(['open']),
-  CODE: new Set(['class']),
+  CODE: new Set(['class', 'data-skill-download']),
   IMG: new Set(['alt', 'height', 'loading', 'src', 'title', 'width']),
 };
 const SAFE_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);

--- a/site/build-release.mjs
+++ b/site/build-release.mjs
@@ -984,10 +984,26 @@ function preprocessTabs(markdown) {
   return output;
 }
 
-function renderStaticMarkdown(markdown) {
+// A fenced code block tagged `skill-source` (e.g. ```` ```markdown skill-source ````)
+// renders as a standard markdown code block that additionally advertises a
+// downloadable filename via `data-skill-download`. The client (app.js) reads
+// that attribute to offer a Download control beside the shared Copy button.
+// Every other code block is rendered exactly as marked's default renderer does.
+function isSkillSourceInfo(infostring) {
+  return String(infostring || "").trim().split(/\s+/).includes("skill-source");
+}
+
+export function renderStaticMarkdown(markdown) {
   const renderer = new marked.Renderer();
   const usedHeadingIds = new Set();
   renderer.image = releaseMarkdownImage;
+  const defaultCode = renderer.code.bind(renderer);
+  renderer.code = (code, infostring, escaped) => {
+    if (isSkillSourceInfo(infostring)) {
+      return `<pre><code class="language-markdown" data-skill-download="SKILL.md">${escapeHtml(code)}\n</code></pre>\n`;
+    }
+    return defaultCode(code, infostring, escaped);
+  };
   renderer.heading = (html, level, rawText) => {
     const baseId = slugifyHeadingText(rawText) || `h${level}`;
     let id = baseId;

--- a/site/styles.css
+++ b/site/styles.css
@@ -955,8 +955,8 @@
     /* Code block with copy button */
     .code-wrap { position: relative; margin-bottom: 20px; }
     .code-wrap pre { margin-bottom: 0; }
-    .code-copy {
-      position: absolute; top: 8px; right: 8px;
+    .code-copy, .code-download {
+      position: absolute; top: 8px;
       width: 30px; height: 30px;
       display: inline-flex; align-items: center; justify-content: center;
       border: 1px solid rgba(255,255,255,0.12);
@@ -966,12 +966,16 @@
       opacity: 0;
       transition: opacity var(--transition), background var(--transition), color var(--transition);
     }
-    .code-copy svg { width: 14px; height: 14px; }
+    .code-copy { right: 8px; }
+    .code-download { right: 46px; }
+    .code-copy svg, .code-download svg { width: 14px; height: 14px; }
     .code-wrap:hover .code-copy,
-    .code-copy:focus-visible { opacity: 1; }
-    .code-copy:hover { background: rgba(255,255,255,0.12); color: #fff; }
-    .code-copy.is-copied { opacity: 1; color: var(--green); border-color: rgba(34,197,94,0.4); background: rgba(34,197,94,0.12); }
-    @media (hover: none) { .code-copy { opacity: 0.75; } }
+    .code-wrap:hover .code-download,
+    .code-copy:focus-visible,
+    .code-download:focus-visible { opacity: 1; }
+    .code-copy:hover, .code-download:hover { background: rgba(255,255,255,0.12); color: #fff; }
+    .code-copy.is-copied, .code-download.is-copied { opacity: 1; color: var(--green); border-color: rgba(34,197,94,0.4); background: rgba(34,197,94,0.12); }
+    @media (hover: none) { .code-copy, .code-download { opacity: 0.75; } }
 
     #article p { margin-bottom: 16px; }
     #article a {
@@ -1017,6 +1021,14 @@
     #article pre code { background: none; border: none; padding: 0; color: inherit; font-size: inherit;
       /* Block code keeps its own horizontal scroll (pre is overflow-x:auto); don't force-wrap it. */
       overflow-wrap: normal; word-break: normal; }
+    /* A full SKILL.md is prose-like source rather than a short command snippet.
+       Preserve its line breaks and indentation, but wrap long lines so the
+       source stays readable without horizontal scrolling on narrow screens. */
+    #article pre code[data-skill-download="SKILL.md"] {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
 
     /* Tables */
     .table-wrap {


### PR DESCRIPTION
> **Updated on current main:** #87 and the #90 cache hotfix are merged. This PR now targets `main`, was rebased onto merge commit `8c5976f`, and has a fresh successful Cloudflare preview plus post-rebase browser smoke evidence.

## What & why (PAP-16980)

Improves SEO/AEO on the bundled/optional **per-skill reference pages** (from PAP-16670) by clearly separating the *human-readable catalog summary* (top of page) from the *authoritative full skill definition*.

Previously the "Full skill definition" section rendered the `SKILL.md` as **parsed Markdown**, so each skill's own `##` headings, lists, and fenced examples became real page content — competing with the summary, inflating the on-page TOC (e.g. qa-acceptance went from **16 → 6** "On this page" entries), and confusing crawlers/answer engines about the page's true structure.

Now each per-skill page shows the **complete, verbatim `SKILL.md`** (frontmatter + body) inline, rendered through the **existing production code-snippet treatment**.

## Changes

- **Content (10 per-skill pages):** replaced the old `### Skill frontmatter` bullets + parsed `### Skill instructions` layout with the full `SKILL.md` embedded in a fenced ````markdown skill-source` block. Source bytes were taken verbatim from each skill's authoritative `SKILL.md` at the page's pinned `paperclip_version`, verified against the page's own prior instructions body + frontmatter (name/description) so no content drifted.
- **Renderers (`site/build-release.mjs`, `site/app.js`):** a `skill-source` fence renders as `<pre><code class="language-markdown" data-skill-download="SKILL.md">`. Every other code block is delegated to marked's default renderer, so existing snippets are byte-for-byte unchanged. Rendered identically in the crawler-visible build HTML and on client SPA navigation.
- **Copy + Download (`site/app.js`, `site/styles.css`):** `decorateCodeBlocks` reuses the existing Copy affordance and adds a **Download `SKILL.md`** control beside it. Both share dimensions, styling, hover/focus visibility, and the copied-success state; both carry accessible labels/titles.
- **Readable full-source wrapping (`site/styles.css`):** only the downloadable `SKILL.md` block uses `white-space: pre-wrap` and safe long-token wrapping. Ordinary code snippets retain the existing horizontal-scroll treatment.
- **Test:** `scripts/verify-skill-source-blocks.mjs` (`npm run docs:test:skill-source-blocks`) asserts the render contract (single H1, single `<pre>`, frontmatter present, no legacy headings) and that ordinary docs pages emit no `data-skill-download`.

## Scope statement

No catalog-page layout, navigation, typography, summary-copy, metadata-card, or information-architecture changes. `paperclip-website` and generated `.site/` output are untouched. `optional/finance/ramp.md` is intentionally excluded — it is a newer summary page with no embedded full-definition section to reformat. The diff is the 10 skill pages + the narrow renderer/Copy-Download support + the test.

## Evidence

**1–2. Before/after (desktop, 1280×900) + mobile after (390×844)** — attached to Paperclip issue [PAP-16980](https://paperclip-dev.tail29c1aa.ts.net/PAP/issues/3098577a-4f6f-4eb2-9151-a4b61917dffd) (`before-desktop.png`, `after-desktop-controls.png`, `after-controls-zoom.png`, `after-mobile.png`). GitHub cannot render the auth-gated attachment URLs inline, so they live on the issue for reviewers.

**4. Raw DOM/HTML (build output, qa-acceptance):**
- Article renders exactly **one H1**: `<h1 id="qa-acceptance">QA Acceptance</h1>`
- Full source inside a single code block:
```html
<pre><code class="language-markdown" data-skill-download="SKILL.md">---
name: qa-acceptance
description: Produce QA acceptance criteria and a manual validation plan …
key: paperclipai/bundled/quality/qa-acceptance
recommendedForRoles:
  - qa
  …
</code></pre>
```
- Article `<pre>` count: **1** (inner ````` fences stay literal — no breakout). 10/10 skill pages carry the block; 0 non-skill pages do.

**5. Copy + Download behavior (Playwright against the built site):**
```json
{
  "downloadFilename": "SKILL.md",
  "downloadMatchesBlock": true,     // downloaded file === code block text, byte-identical
  "downloadBytes": 3853,
  "copyShowsSuccess": true,          // Copy toggles the existing is-copied success state
  "accessibleLabels": { "copy": "Copy code", "download": "Download SKILL.md" }
}
```
Both controls reach `opacity: 1` on `.code-wrap:hover` and on keyboard `:focus-visible` (verified `matches(':focus-visible') === true` → computed opacity `1`).

**H1 audit (every generated route, incl. all skill URLs — requested on the issue):** built the site on current `main` and scanned **all 184 generated `index.html` routes** (16 skill routes among them). **Every route has exactly one `<h1>`.** The skill source's own `#`/`##` headings live *inside* the `<pre><code>` block as literal text, so they do **not** create competing H1s — the SEO/AEO goal.

## Tests

Run against current `main` after #87 and #90:

```
docs:build ............................. ok (184 routes)
docs:test:static-routes ................ pass (5 routes + 404 + root + subpath)
docs:test:skill-source-blocks .......... pass (10 skill pages, 1 control page)
H1 audit (all 184 routes) .............. pass (exactly 1 h1 each; 16 skill routes)
```

**Do not merge/deploy** — returning to Dotta/reviewers for approval per PAP-16980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)