### PR TITLE
URGENT: fingerprint docs client bundle to fix mixed-version cache regression (PAP-16990)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "docs:build:github-subpath": "node site/build-release.mjs --base-path /paperclip-docs/ --out-dir .site",
     "docs:build:auto": "node site/build-release.mjs --base-path auto --out-dir .site",
     "docs:test:static-routes": "node scripts/verify-static-routes.mjs",
+    "docs:test:asset-fingerprints": "node scripts/verify-asset-fingerprints.mjs",
     "docs:test:hierarchical-skills-nav": "node scripts/verify-hierarchical-skills-nav.mjs",
     "docs:serve": "python3 -m http.server 4321 --directory .site",
     "sync:lint-links": "node scripts/sync/lint-links.mjs",

--- a/scripts/verify-asset-fingerprints.mjs
+++ b/scripts/verify-asset-fingerprints.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/* PAP-16990 regression coverage.
+ *
+ * The docs root is server-rendered, but the client bundle used to load from a
+ * stable URL (`/app.js`). Cloudflare and browsers cache that URL for hours
+ * independently of the HTML, so a returning visitor could pair freshly
+ * revalidated HTML with a pre-merge cached bundle — the old click path looked
+ * for `#loading`/`#error-state`, threw, and blanked the page.
+ *
+ * This test proves the build closes that window: the client bundle is emitted
+ * under a content-fingerprinted URL, every generated route references it, and
+ * the URL changes whenever the bundle's bytes change. It also checks the
+ * Cloudflare cache headers that let the fingerprinted assets be cached
+ * immutably while HTML and content.json keep revalidating.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fingerprintAssetName } from "../site/build-release.mjs";
+
+const root = process.cwd();
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+/* ─── Unit: the fingerprint is stable and content-sensitive ──────────────── */
+const nameA = fingerprintAssetName("app.js", "console.log(1)");
+const nameA2 = fingerprintAssetName("app.js", "console.log(1)");
+const nameB = fingerprintAssetName("app.js", "console.log(1) ");
+assert(nameA === nameA2, "fingerprint must be stable for identical content");
+assert(nameA !== nameB, "fingerprint must change when a single byte of content changes");
+assert(/^app\.[0-9a-f]+\.js$/.test(nameA), `fingerprinted name has the wrong shape: ${nameA}`);
+assert(fingerprintAssetName("styles.css", "a{}").match(/^styles\.[0-9a-f]+\.css$/), "styles fingerprint has the wrong shape");
+
+/* ─── Build once and check the emitted bundle is fingerprinted end to end ── */
+const outDir = mkdtempSync(join(tmpdir(), "paperclip-docs-fingerprints-"));
+try {
+  const build = spawnSync(process.execPath, [
+    "site/build-release.mjs",
+    "--base-path",
+    "/",
+    "--out-dir",
+    outDir,
+  ], { cwd: root, encoding: "utf8" });
+  assert(
+    build.status === 0,
+    `docs build failed\nstdout:\n${build.stdout}\nstderr:\n${build.stderr}`,
+  );
+
+  const read = (rel) => readFileSync(join(outDir, rel), "utf8");
+  const rootHtml = read("index.html");
+
+  // The root HTML references a fingerprinted bundle, and that file exists.
+  const appRefMatch = rootHtml.match(/src="(app\.[0-9a-f]+\.js)"/);
+  assert(appRefMatch, "root HTML does not reference a fingerprinted app.js bundle");
+  const appJsName = appRefMatch[1];
+  assert(existsSync(join(outDir, appJsName)), `referenced bundle ${appJsName} was not emitted`);
+
+  // The unversioned names must be gone — a stale cache must have nothing to pin.
+  assert(!existsSync(join(outDir, "app.js")), "release still emits an unversioned app.js");
+  assert(!existsSync(join(outDir, "styles.css")), "release still emits an unversioned styles.css");
+  assert(
+    !/(?:src|href)="(?:app|styles)\.(?:js|css)"/.test(rootHtml),
+    "root HTML still references an unversioned asset URL",
+  );
+
+  // The URL is derived from the emitted bytes: recomputing the hash over the
+  // served bundle must reproduce exactly the filename in the HTML. Combined
+  // with the content-sensitivity unit test above, this proves the asset URL
+  // changes whenever the bundle content changes.
+  const servedBytes = read(appJsName);
+  assert(
+    fingerprintAssetName("app.js", servedBytes) === appJsName,
+    "the emitted bundle URL is not the content fingerprint of the bytes it serves",
+  );
+
+  // Exactly one fingerprinted bundle should exist (no stale siblings).
+  const bundles = readdirSync(outDir).filter((f) => /^app\.[0-9a-f]+\.js$/.test(f));
+  assert(bundles.length === 1, `expected exactly one fingerprinted bundle, found ${bundles.length}: ${bundles}`);
+
+  // Every generated route must point at the same bundle so navigation between
+  // them can never swap client versions mid-session.
+  const skillsHtml = read("reference/skills/index.html");
+  assert(skillsHtml.includes(`src="${appJsName}"`), "interior route references a different bundle than the root");
+  const interiorRef = skillsHtml.match(/src="(app\.[0-9a-f]+\.js)"/);
+  assert(interiorRef && interiorRef[1] === appJsName, "interior route bundle URL diverged from the root");
+
+  // Cache headers: fingerprinted assets immutable; HTML + content.json revalidate.
+  const headers = read("_headers");
+  assert(
+    headers.includes("/app.*.js\n  Cache-Control: public, max-age=31536000, immutable"),
+    "_headers is missing the immutable cache rule for fingerprinted JS",
+  );
+  assert(
+    headers.includes("/styles.*.css\n  Cache-Control: public, max-age=31536000, immutable"),
+    "_headers is missing the immutable cache rule for fingerprinted CSS",
+  );
+  assert(
+    headers.includes("/\n  Cache-Control: public, max-age=0, must-revalidate"),
+    "_headers is missing the revalidate rule for the docs root HTML",
+  );
+  assert(
+    headers.includes("/*/\n  Cache-Control: public, max-age=0, must-revalidate"),
+    "_headers is missing the revalidate rule for interior route directories",
+  );
+  assert(
+    headers.includes("/content.json\n  Cache-Control: public, max-age=0, must-revalidate"),
+    "_headers is missing the revalidate rule for content.json",
+  );
+
+  console.log(`Asset fingerprint verification passed (bundle ${appJsName}, ${bundles.length} bundle, headers checked).`);
+} finally {
+  rmSync(outDir, { recursive: true, force: true });
+}

--- a/scripts/verify-static-routes.mjs
+++ b/scripts/verify-static-routes.mjs
@@ -97,7 +97,8 @@ try {
   assert(skillsHtml.includes('<base data-seo-base href="/" />'), "nested route is missing the release base path");
   assert(skillsHtml.includes("<style data-inline-release-css>"), "nested route does not inline release CSS");
   assert(!skillsHtml.includes('rel="stylesheet" href="styles.css"'), "nested route still render-blocks on styles.css");
-  assert(skillsHtml.includes('src="app.js"'), "nested route does not load app JS from the release base path");
+  const skillsAppJsMatch = skillsHtml.match(/src="(app\.[0-9a-f]+\.js)"/);
+  assert(skillsAppJsMatch, "nested route does not load a fingerprinted app JS bundle from the release base path");
   assert(skillsHtml.includes("html:not(.motion-ready) *"), "nested route is missing the first-paint motion gate");
 
   const rootHtml = read("index.html");
@@ -133,7 +134,10 @@ try {
   assert(glossaryHtml.includes('<h3 id="board-operator">Board Operator</h3>'), "glossary route is missing the Board Operator term anchor");
   assert(glossaryHtml.includes('<h3 id="heartbeat">Heartbeat</h3>'), "glossary route is missing the Heartbeat term anchor");
 
-  const appJs = read("app.js");
+  const rootAppJsMatch = rootHtml.match(/src="(app\.[0-9a-f]+\.js)"/);
+  assert(rootAppJsMatch, "root HTML does not reference a fingerprinted app JS bundle");
+  assert(!existsSync(join(outDir, "app.js")), "release still emits an unversioned app.js that a stale cache could pin");
+  const appJs = read(rootAppJsMatch[1]);
   assert(!appJs.includes("/#/"), "generated app JS still contains primary hash route URLs");
 
   const sitemap = read("sitemap.xml");

--- a/site/build-release.mjs
+++ b/site/build-release.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 import { transform } from "esbuild";
 import { marked } from "marked";
 
@@ -738,6 +739,27 @@ function buildCloudflareHeaders() {
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
   Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'none'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.github.com; upgrade-insecure-requests
 
+# PAP-16990 cache policy. HTML shells must always revalidate so a returning
+# visitor never renders a stale document that points at a since-changed bundle.
+# Path routes are extensionless directories, so the docs root and every route
+# directory are matched explicitly. Fingerprinted JS/CSS carry a content hash in
+# the URL and are safe to cache immutably; content.json ships per release with
+# the exact-version bundle, so it revalidates alongside the HTML.
+/
+  Cache-Control: public, max-age=0, must-revalidate
+
+/*/
+  Cache-Control: public, max-age=0, must-revalidate
+
+/app.*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/styles.*.css
+  Cache-Control: public, max-age=31536000, immutable
+
+/content.json
+  Cache-Control: public, max-age=0, must-revalidate
+
 /sitemap.xml
   Content-Type: application/xml; charset=utf-8
   X-Robots-Tag: noindex, nofollow
@@ -979,10 +1001,31 @@ function renderStaticMarkdown(markdown) {
 }
 
 function inlineReleaseStyles(html, css) {
+  // Match the stylesheet link whether or not its href has been content-
+  // fingerprinted (styles.css or styles.<hash>.css) so inlining keeps working.
   return html.replace(
-    '<link rel="stylesheet" href="styles.css" />',
+    /<link rel="stylesheet" href="styles(?:\.[0-9a-f]+)?\.css" \/>/,
     `<style data-inline-release-css>${css}</style>`,
   );
+}
+
+// Derive a content-fingerprinted filename (e.g. app.js -> app.<hash>.js). The
+// hash is over the exact bytes that ship, so the URL changes if and only if the
+// asset's contents change. Exported for the fingerprint regression test.
+export function fingerprintAssetName(filename, content) {
+  const dot = filename.lastIndexOf(".");
+  const stem = filename.slice(0, dot);
+  const ext = filename.slice(dot);
+  const hash = createHash("sha256").update(content).digest("hex").slice(0, 12);
+  return `${stem}.${hash}${ext}`;
+}
+
+// Point the shell's external asset references at their fingerprinted URLs so
+// every generated route loads the exact bundle it was built with (PAP-16990).
+function rewriteAssetReferences(html, { appJsName, stylesName }) {
+  return html
+    .replace('src="app.js"', `src="${appJsName}"`)
+    .replace('href="styles.css"', `href="${stylesName}"`);
 }
 
 /* ─── Server-rendered homepage directory ──────────────────────────────────
@@ -1270,11 +1313,20 @@ async function main() {
   const sourceStyles = await fs.readFile(sourceStylesPath, "utf8");
   const sourceAppJs = await fs.readFile(sourceAppJsPath, "utf8");
   const sectionIconPaths = extractSectionIconPaths(sourceAppJs);
-  const sourceIndex = linkDocsRootAnchors(rawSourceIndex, options.basePath);
   const releaseStyles = minifyCss(sourceStyles);
-  const releaseAppJs = rewriteAppJs(sourceAppJs, options.basePath);
-  await fs.writeFile(path.join(options.outDir, "styles.css"), releaseStyles);
-  await fs.writeFile(path.join(options.outDir, "app.js"), await minifyJs(releaseAppJs));
+  const releaseAppJs = await minifyJs(rewriteAppJs(sourceAppJs, options.basePath));
+  // Content-fingerprint the external client bundle so a returning browser can
+  // never combine freshly revalidated HTML with a stale cached app.js. Every
+  // generated route references this exact build's asset URL; a changed bundle
+  // gets a brand-new URL that no cache can satisfy with old bytes (PAP-16990).
+  const appJsName = fingerprintAssetName("app.js", releaseAppJs);
+  const stylesName = fingerprintAssetName("styles.css", releaseStyles);
+  const sourceIndex = rewriteAssetReferences(
+    linkDocsRootAnchors(rawSourceIndex, options.basePath),
+    { appJsName, stylesName },
+  );
+  await fs.writeFile(path.join(options.outDir, stylesName), releaseStyles);
+  await fs.writeFile(path.join(options.outDir, appJsName), releaseAppJs);
   if (await pathExists(sourceVendorDir)) {
     await copyDirRecursive(sourceVendorDir, path.join(options.outDir, "vendor"));
   }


### PR DESCRIPTION
## Urgent hotfix — mixed-version asset cache regression (PAP-16990)

Restores reliable navigation on https://docs.paperclip.ing/ without undoing the PAP-16670/#87 server-render + single-H1 SEO/AEO work.

### Root cause
The server-render change shipped new HTML that removed `#loading` / `#error-state`, but every generated route still loaded the client bundle from a **stable URL**: `<script src="app.js" defer>`. Cloudflare/browsers cache `/app.js` for up to ~4h independently of the HTML, so a returning visitor could pair freshly-revalidated new HTML with a **pre-merge cached `app.js`**. The old click path looked for the removed elements, threw before render, hid the homepage, and left a blank `#main` (no URL update). Forced refresh recovered — not acceptable.

CSS was never part of this: it is inlined into every page and travels with the (revalidating) HTML. `content.json` is byte-identical prod↔preview.

### Fix (narrow cache-bust, no rollback)
1. **Content-fingerprint the client bundle.** Emit `app.<hash>.js` (+ `styles.<hash>.css`) and rewrite the shell so *every* route references the exact build's asset URL. A changed bundle gets a brand-new URL no cache can satisfy with stale bytes — closes the mixed-version window in **both** directions. No unversioned `/app.js` is emitted, so a stale cache has nothing to pin.
2. **`_headers`:** fingerprinted JS/CSS cached `immutable` (1y); HTML routes (`/`, `/*/`) and `content.json` set `max-age=0, must-revalidate`.
3. `inlineReleaseStyles` now matches the fingerprinted stylesheet link so CSS stays inlined.

### Before / after
```
- <script src="app.js" defer></script>          # stable URL — cacheable across versions
+ <script src="app.1b669c8d0aec.js" defer></script>   # content-hash URL — cache miss on any change
```
`_headers` (new):
```
/app.*.js
  Cache-Control: public, max-age=31536000, immutable
/
/*/
  Cache-Control: public, max-age=0, must-revalidate
/content.json
  Cache-Control: public, max-age=0, must-revalidate
```

### Verification (local build, base path `/`)
- `npm run docs:build` → emits `app.1b669c8d0aec.js`, `styles.9e3f24983c72.css`; **184/185** HTML files reference the fingerprinted bundle (185th is the scriptless `404.html`); **no** bare `app.js`/`styles.css` file or reference remains.
- `npm run docs:test:asset-fingerprints` ✅ (new) — proves the URL is the content hash of the served bytes, changes on any content change, is referenced identically by root + interior routes, has no unversioned sibling, and the cache headers are present.
- `npm run docs:test:static-routes` ✅ — single-H1 interior pages, no-JS server-render, homepage manifest completeness, 404 separation, root + `/paperclip-docs/` builds.

### Remaining (post-merge, needs a real browser on the live domain)
Chromium can't launch in the CI/agent sandbox (missing system libs), so **cold + returning/cached** browser smoke on https://docs.paperclip.ing/ must be run after merge → redeploy from `main`. Checklist: cold load, homepage-card nav (URL updates, one H1, no blank), interior↔interior, Back/Forward, All Docs, search, 404, and a returning/cached session (prior `/app.js` in cache).

Does **not** touch the SKILL.md formatting PR (PAP-16980), per the issue.
