### PR TITLE
docs: redirect legacy what-is-paperclip URL

### DIFF
--- a/site/redirects.json
+++ b/site/redirects.json
@@ -40,6 +40,7 @@
   "user-guides/guides/administration/plugins": "administration/plugins",
   "start/quickstart": "guides/getting-started/five-minute-path",
   "start/core-concepts": "guides/welcome/key-concepts",
+  "start/what-is-paperclip": "guides/welcome/what-is-paperclip",
   "tutorials": "guides/getting-started/five-minute-path",
   "how-to": "how-to/enable-multi-user-login",
   "glossary": "guides/welcome/glossary",


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses a public documentation site to help users learn the product.
> - The site build reads legacy routes from `site/redirects.json`.
> - Two old `/start/` routes redirect to current guide pages.
> - The old `/start/what-is-paperclip` route has no matching redirect.
> - Search engines still send users to that old route.
> - This pull request adds the missing redirect entry.
> - The benefit is a working 301 response for both slash variants.

## Linked Issues or Issue Description

**Issue type**

Outdated documentation route.

**Where is the issue?**

`https://docs.paperclip.ing/start/what-is-paperclip`

**What's wrong?**

The legacy URL returns a hard 404. The live replacement is `/guides/welcome/what-is-paperclip/`.

**Suggested fix**

Add the proven legacy path to `site/redirects.json`. Do not add speculative `/start/` redirects.

## What Changed

- Added `start/what-is-paperclip` to the legacy redirect map.
- Kept the existing `start/quickstart` and `start/core-concepts` mappings unchanged.

## Verification

- Ran `npm run docs:test:static-routes` successfully.
- Ran `npm run docs:build` successfully.
- Confirmed the generated `_redirects` file contains 301 rules for both `/start/what-is-paperclip` variants.
- Confirmed the generated sibling rules remain present.

## Risks

- Low risk. The change adds one redirect map entry and does not change page content or route generation logic.

## Model Used

- OpenAI `gpt-5.4` through Codex CLI, with reasoning, tool use, and code execution. The runtime does not expose the context window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All configured CI gates are green
- [x] No Greptile check is configured for this repository, and no Greptile comments are open
- [x] I will address all Greptile and reviewer comments before requesting merge
