### PR TITLE
docs: clarify GitHub App secret storage pattern

### DIFF
--- a/docs/how-to/connect-agent-to-github.md
+++ b/docs/how-to/connect-agent-to-github.md
@@ -133,7 +133,40 @@ A GitHub App installed on the org issues short-lived installation tokens, isn't 
 3. Generate a private key, download the `.pem`. Note the App ID and the installation ID for the target repo.
 4. Mint installation tokens with `gh auth token --hostname github.com` (App-aware) or a small script using `actions/create-github-app-token`'s logic.
 
-Store the App ID, installation ID, and private key as Paperclip secrets, and have the agent's heartbeat exchange them for an installation token at the start of each run. The token expires in an hour, which is exactly long enough for one heartbeat.
+A Paperclip secret holds one value, so the App ID, installation ID, and private key each need their own secret — there's no single "GitHub App" secret with three fields.
+
+```bash
+curl -X POST "$PAPERCLIP_API_URL/api/companies/$COMPANY_ID/secrets" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "GITHUB_APP_ID", "value": "123456" }'
+
+curl -X POST "$PAPERCLIP_API_URL/api/companies/$COMPANY_ID/secrets" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "GITHUB_APP_INSTALLATION_ID", "value": "78901234" }'
+
+curl -X POST "$PAPERCLIP_API_URL/api/companies/$COMPANY_ID/secrets" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data-binary @- <<'EOF'
+{ "name": "GITHUB_APP_PRIVATE_KEY", "value": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----" }
+EOF
+```
+
+The private key's `value` is a single string, so keep the PEM's newlines escaped as `\n` in the JSON payload — paste the raw multi-line `.pem` and the request will fail JSON parsing.
+
+Then reference all three on the coder agent's adapter config, the same `env` block used in Option A above:
+
+```json
+"env": {
+  "GITHUB_APP_ID":              { "type": "secret_ref", "secretId": "<app-id-secret-id>", "version": "latest" },
+  "GITHUB_APP_INSTALLATION_ID": { "type": "secret_ref", "secretId": "<installation-id-secret-id>", "version": "latest" },
+  "GITHUB_APP_PRIVATE_KEY":     { "type": "secret_ref", "secretId": "<private-key-secret-id>", "version": "latest" }
+}
+```
+
+Have the agent's heartbeat script read those three env vars and exchange them for an installation token at the start of each run — the token expires in an hour, which is exactly long enough for one heartbeat.
 
 **Tradeoff:** more moving parts, a one-time setup that takes 15 extra minutes. Worth it the moment you have more than one coding agent or you care about audit trails.
 


### PR DESCRIPTION
Fixes paperclipai/paperclip#10902

The `connect-agent-to-github` how-to told readers to store the GitHub App's ID, installation ID, and private key as "Paperclip secrets" without saying how, given that the Secret UI/API only exposes a single `value` field per secret.

**Verified against the actual storage model** (in `paperclipai/paperclip`):
- `packages/db/src/schema/company_secrets.ts` / `company_secret_versions.ts`: each secret row has one `key`/`name` and its versions hold a single `material`/value — there is no multi-field secret object.
- `packages/shared/src/validators/secret.ts`: `createSecretSchema.value` is `z.string()` — one string per secret, confirming a GitHub App's three credentials require three separate secrets.

**Doc change:** Option B (GitHub App) now shows creating three named secrets (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY`) via the existing secrets API, a note on escaping the PEM's newlines as `\n` in the JSON payload, and an `env` block referencing all three via `secret_ref` — mirroring the pattern already used for Option A (PAT) earlier in the same doc.

## Test plan
- [x] Read the rendered markdown diff for formatting/typos
- [x] Cross-checked secret storage claims against `company_secrets`/`company_secret_versions` schema and `createSecretSchema` in the `paperclip` monorepo
- Docs-only change, no code/build to run