### PR TITLE
Add the v2026.817.0 docs changelog entry, and a step that writes it

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,5 +1,5 @@
 ---
-paperclip_version: v2026.722.0
+paperclip_version: v2026.817.0
 ---
 
 # Documentation Changelog
@@ -11,6 +11,39 @@ The docs track Paperclip's [calendar-versioned](https://github.com/paperclipai/p
 ---
 
 <details class="accordion" open>
+<summary>Docs for v2026.817.0 <span class="accordion-meta">August 17, 2026</span></summary>
+<div class="accordion-body">
+
+**New pages**
+
+- [Decisions API](api/decisions.md) — proposing and resolving decisions, decision bundles, named queues, triage (decide-by and snooze), and the retention/archive routes.
+- [Status Cards API](api/status-cards.md) — the shared status-card board: creating cards, the compiled query, summary writes and revisions, refresh policy, and the agent-authoring limits.
+- [Status Cards](../experimental/status-cards.md) — the experimental board itself: writing the one message that drives a card, reading the tiles, the five card states, what counts as a change, and what it costs.
+- [Chat-Style Tasks](../experimental/task-chat.md) — the experimental task page as a live conversation: bubbles, folding turns, inline tool calls and diffs, the three-mode composer, and the resizable side pane.
+- [`service` CLI](cli/service.md) — installing, starting, and inspecting Paperclip as a background service.
+- [Status Card Query skill](skills/bundled/paperclip-operations/status-card-query.md) — the bundled skill that teaches an agent to manage status cards.
+- [Simplified English skill](skills/optional/content/simplified-english.md) and [Prepare MCP Integration skill](skills/optional/software-development/prepare-mcp-integration.md) — two new optional catalog skills.
+
+**Updated pages**
+
+- [Decisions](../guides/day-to-day/decisions.md) — named queues, triage deadlines, and answering an agent-proposed decision, now with screenshots throughout.
+- [Secrets API](api/secrets.md) — agent secret proposals: what an agent may propose, the run-bound agent-token requirement, and the board-side approve/reject flow.
+- [Activity Log API](api/activity.md) — the audit feed of agent actions, its two-tier access model, and CSV export. `/audit` has merged into the single Activity page.
+- [Plugin SDK](plugins/sdk.md) — responding to interactions and approvals, and the rules for handling adapter-authored `command` operations and re-validating `cwd` before executing.
+- [Back up and restore a company](../how-to/back-up-and-restore-a-company.md) — what the bundle deliberately leaves behind, uploading the zip instead of inline JSON, and running large imports as a background job.
+- [Update Paperclip](../how-to/update-paperclip.md) — rewritten around checking before you commit, switching channels, rolling back, and the pre-update backup.
+- [Cloud CLI](cli/cloud.md) — the cloud-upstream commands are retired; the page now points at what replaced them.
+- [Issues API](api/issues.md), [Attention API](api/attention.md), [Environment Variables](deploy/environment-variables.md), [CLI installation](cli/installation.md), [Export & import](../guides/power/export-import.md), [Sandbox providers](adapters/sandbox-providers.md), [Skills reference](skills.md), and [Issues](../guides/day-to-day/issues.md) — brought in line with the release.
+
+**Screenshots**
+
+- Every screenshot was recaptured against v2026.817.0 — 342 images, light and dark. The previous set was 375 parent-commits old.
+- New coverage for Decisions, Status Cards, Chat-Style Tasks, and the secret-proposal review tab. Those first three guides previously shipped with no images at all.
+
+</div>
+</details>
+
+<details class="accordion">
 <summary>Docs for v2026.722.0 <span class="accordion-meta">July 22, 2026</span></summary>
 <div class="accordion-body">
 

--- a/skills/sync-docs/SKILL.md
+++ b/skills/sync-docs/SKILL.md
@@ -31,6 +31,7 @@ The branch model is non-negotiable: end users on the latest *released* paperclip
 - `docs/user-guides/screenshots/registry.json` — read/write: screenshot dependency tracking.
 - `PENDING.md` (on `nightly` branch only) — **regenerated** from scratch each run (not appended) so it always reflects the current cumulative manifest. Stale entries from reverted commits never linger.
 - `SCREENSHOTS_PENDING.md` (committed) — regenerated each run, lists screenshots whose `depends_on` paths changed in the diff window.
+- `docs/reference/changelog.md` — **release mode only**: append one accordion entry per release (Phase 6.5). User-facing and linked from the nav; nothing else writes it.
 
 **Helper scripts called during the run:**
 
@@ -281,6 +282,61 @@ Capture is now automatable via the screenshot pipeline:
   ```
 
 Both commands spin up an isolated `local_trusted` / `loopback` Paperclip instance, seed it with demo data, capture light + dark variants at 1440×900 @2x, and stamp `captured_sha` / `captured_against` in `registry.json`. The output PNGs land in a PR for human review — they are **never auto-pushed**. See [`scripts/screenshots/README.md`](../../scripts/screenshots/README.md) for prerequisites and full details.
+
+### Phase 6.5 — Documentation changelog (release mode only)
+
+`docs/reference/changelog.md` is a changelog for **these docs** — pages added,
+rewritten, or expanded per release — not for the product. It is user-facing and
+linked from the nav, and nothing else writes it, so it silently goes stale unless
+this phase runs. (It did: the page was created in July 2026 with two backfilled
+entries and then missed the very next release.)
+
+Skip entirely in nightly mode — nightly pages are versionless until they merge to
+`main`, and a changelog entry for an unreleased tag would leak.
+
+1. Read the current top entry to match its shape. The format is a `<details>`
+   accordion, newest first:
+
+   ```html
+   <details class="accordion" open>
+   <summary>Docs for vYYYY.MDD.P <span class="accordion-meta">Month D, YYYY</span></summary>
+   <div class="accordion-body">
+
+   **New pages**
+
+   - [Title](relative/path.md) — one line on what it covers.
+
+   **Updated pages**
+
+   - [Title](relative/path.md) — one line on what changed.
+
+   </div>
+   </details>
+   ```
+
+2. **Only the newest entry carries `open`.** Remove `open` from the previous top
+   entry when you insert the new one, or the page renders with two expanded.
+
+3. Build the entry from the manifest you already have, not from a fresh diff:
+   - **New pages** — every page created this window. Link text is the page title.
+   - **Updated pages** — the substantive rewrites. Lead with the reader's benefit
+     ("what an agent may propose, and the board-side approve/reject flow"), not
+     the mechanics of the diff. Roll trivial one-liners into a single trailing
+     bullet rather than listing each.
+   - **Screenshots** — add a short block when a release recaptured them, saying
+     what was reshot and what gained first-time coverage.
+
+4. Links are relative to `docs/reference/`: a sibling is `api/secrets.md`, a page
+   elsewhere under `docs/` is `../guides/day-to-day/decisions.md`.
+
+5. Bump the page's own `paperclip_version` frontmatter to the release tag.
+
+6. Exclude maintenance files that are not user-facing pages (anything under
+   `docs/user-guides/screenshots/`, `SCREENSHOTS_*.md`, plan documents). They are
+   in the repo, not in the docs.
+
+Phase 7's `sync:check` catches a bad relative link here, so a typo fails the run
+rather than shipping.
 
 ### Phase 7 — Verify & commit
 


### PR DESCRIPTION
The documentation changelog was never updated for v2026.817.0. This adds the
missing entry, and closes the hole that let it go missing.

## Why it was missing

`docs/reference/changelog.md` has **exactly one commit in its entire history** —
`8c21935` (#73), which created the page on 2026-07-23 with the v2026.722.0 and
v2026.720.0 entries written by hand. `skills/sync-docs/SKILL.md` contains zero
occurrences of "changelog": release mode merges nightly → main, tags, and ships,
but never writes that page.

The timing is why nobody noticed:

| | |
|---|---|
| 2026-07-23 08:10 | v2026.722.0 release merged (#72) |
| 2026-07-23 11:47 | changelog page created (#73), already current |
| 2026-08-18 10:43 | v2026.817.0 merged (#95) ← first release that had to append |

The page was born ~3.5 hours after the previous release, so it was correct on
arrival. v2026.817.0 is the first one it could have missed, and it did. The
frontmatter was stale by the same marker (`paperclip_version: v2026.722.0`).

## What's here

**The entry** — 8 new pages (Decisions API, Status Cards API and guide,
Chat-Style Tasks, the `service` CLI, three catalog skills), the substantive
rewrites grouped by what a reader gains, and a short block on the screenshot
overhaul. Frontmatter bumped to `v2026.817.0`.

**Phase 6.5 in the sync-docs skill** (release mode only) — writes this page from
the manifest the run already holds. It pins down the details that are easy to get
wrong on a monthly cadence:

- the `<details class="accordion">` shape, newest first
- **only the newest entry carries `open`** — miss this and the page renders with
  two expanded
- links are relative to `docs/reference/`
- exclude repo maintenance files (`docs/user-guides/screenshots/`,
  `SCREENSHOTS_*.md`) — they're in the repo, not in the docs
- skip entirely in nightly mode, so an unreleased tag can't leak

Phase 7's `sync:check` already validates relative links, so a typo in a future
entry fails the run instead of shipping.

## Checks

- `npm run docs:build` — clean, 191 pages
- `npm run sync:lint-links` — no broken internal links
- Rendered output verified: v2026.817.0 sits on top with **exactly one** open
  accordion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
