### PR TITLE
docs: document Ask agent for recommendation on the Decisions desk

### DIFF
--- a/docs/guides/day-to-day/decisions.md
+++ b/docs/guides/day-to-day/decisions.md
@@ -91,13 +91,39 @@ Filters tidy your view. **Triage** does something different: it records, for eve
 
 You can give any item a decide-by target of **today**, **this week**, **whenever**, or a specific calendar date, and you can snooze it until a moment in the future. Both stick to the item itself rather than to your browser, so the deadline your colleague set is the deadline you see. Paperclip keeps a history of who changed what.
 
-![The triage strip on an expanded row: a When to decide row offering Today, This week, Whenever, and Pick date, alongside Queues and Snooze controls](../../user-guides/screenshots/light/decisions/triage-chips.png)
+![The triage strip on an expanded row: a When to decide row offering Today, This week, Whenever, and Pick date, above Queues, with Snooze and Ask agent for recommendation controls below](../../user-guides/screenshots/light/decisions/triage-chips.png)
 
 Triage changes how the queue reads in two ways. The feed can rank by deadline instead of recent activity — soonest first, then the *whenever* pile, then everything nobody has triaged yet. And the sidebar badge deliberately counts only what is due today, so it stays a signal about this morning rather than a running total of everything outstanding.
 
 Set triage in the UI with the **When to decide** row on an expanded item. You can also set it through the [Decisions API](../../reference/api/decisions.md).
 
 > Triage snoozing is not the same as the personal snooze below. A triage snooze hides the item for the whole company; the snooze in your queue is yours alone.
+
+---
+
+## Ask an agent for a recommendation
+
+Most of this page describes agents bringing work to you. This control runs the other way: it asks a named agent to go and look at something on the desk and come back with a view on it.
+
+**Ask agent for recommendation** sits in the same triage strip as **When to decide**, beside **Snooze**, on an expanded row. Open it and pick an agent from the list.
+
+Paperclip then posts one comment on the task behind the item. The comment mentions the agent you picked, asks it to look at the decision, prepare a recommendation, and re-surface it on the decisions desk, and notes that the request came from here. It is attributed to you like any other comment you write, and it lands in the task thread where the agent and anyone else following that work will see it.
+
+That comment is the whole of what Paperclip does. In particular:
+
+- **It does not reassign the task.** Whoever the task was assigned to before still owns it, and the agent you asked does not become the assignee.
+- **It does not answer the decision.** Nothing is decided, dismissed, or resolved, and no option is chosen on your behalf.
+- **It does not move the item on the desk.** Its queues, decide-by target, and snooze are left exactly as they were.
+
+So you are sending a request, not handing over the call. What comes back — a comment weighing the options, a question, a proposed decision of its own — is up to the agent you asked, and you still make the final decision here.
+
+The button is greyed out in three cases:
+
+- **The item has no task behind it.** Budget alerts and join requests often have nothing to comment on; hovering the button explains why with *No linked task to ask about*.
+- **There is no agent to ask.** The list covers your company's active agents, so a company with none available has nobody to route to. Terminated agents are never offered.
+- **Your last request is still going out.** The button settles once the comment has posted, and a confirmation names the agent you asked.
+
+You will find the control on rows in your active queue. Rows you have already dismissed or snoozed collapse into their own sections without the triage strip, so restore a row first if you want to ask about it.
 
 ---
 

--- a/docs/guides/day-to-day/decisions.md
+++ b/docs/guides/day-to-day/decisions.md
@@ -117,7 +117,7 @@ That comment is the whole of what Paperclip does. In particular:
 
 So you are sending a request, not handing over the call. What comes back — a comment weighing the options, a question, a proposed decision of its own — is up to the agent you asked, and you still make the final decision here.
 
-One thing the list does not tell you is whether the agent can reply yet. Every agent that has not been terminated is offered, including ones you have paused or have not approved yet; those receive the comment but are not woken to act on it until you resume or approve them. If you want an answer soon, pick an agent that is idle or running.
+One thing the list does not tell you is whether the agent can reply yet. Every agent that has not been terminated is offered, including ones you have paused or have not approved yet. Those agents get the comment, but nothing wakes them to act on it, and resuming or approving the agent later does not replay the request: no part of Paperclip re-delivers that comment when the agent comes back. Resume or approve the agent first, then ask. If you want an answer soon, pick an agent that is idle or running.
 
 The button is greyed out in three cases:
 

--- a/docs/guides/day-to-day/decisions.md
+++ b/docs/guides/day-to-day/decisions.md
@@ -117,10 +117,12 @@ That comment is the whole of what Paperclip does. In particular:
 
 So you are sending a request, not handing over the call. What comes back — a comment weighing the options, a question, a proposed decision of its own — is up to the agent you asked, and you still make the final decision here.
 
+One thing the list does not tell you is whether the agent can reply yet. Every agent that has not been terminated is offered, including ones you have paused or have not approved yet; those receive the comment but are not woken to act on it until you resume or approve them. If you want an answer soon, pick an agent that is idle or running.
+
 The button is greyed out in three cases:
 
-- **The item has no task behind it.** Budget alerts and join requests often have nothing to comment on; hovering the button explains why with *No linked task to ask about*.
-- **There is no agent to ask.** The list covers your company's active agents, so a company with none available has nobody to route to. Terminated agents are never offered.
+- **The item has no task behind it.** Agent alerts, budget alerts, and join requests often have nothing to comment on; hovering the button explains why with *No linked task to ask about*.
+- **There is no agent to ask.** The list covers every agent in your company that has not been terminated, so a company with no other agents has nobody to route to.
 - **Your last request is still going out.** The button settles once the comment has posted, and a confirmation names the agent you asked.
 
 You will find the control on rows in your active queue. Rows you have already dismissed or snoozed collapse into their own sections without the triage strip, so restore a row first if you want to ask about it.

--- a/docs/reference/api/decisions.md
+++ b/docs/reference/api/decisions.md
@@ -456,6 +456,8 @@ Writes are serialised per source and bump `version`, so two people triaging the 
 
 Triage feeds straight back into the attention feed: `decideBy` and `snoozedUntil` appear on each item, `sort=decide` orders by deadline, and `decideNowCount` counts what is due today. See [Attention](./attention.md) for how that ranking works.
 
+> **Not everything in the triage strip is a Decisions route.** The strip's **When to decide**, queue, and snooze controls map onto the routes above. **Ask agent for recommendation** does not: it posts an ordinary comment mentioning an agent on the issue behind the item, through [Add Comment](./issues.md#add-comment). There is no Decisions endpoint that asks an agent for a recommendation, and the control changes nothing about the decision, its triage, or the assignee of the issue it comments on. See [Decisions](../../guides/day-to-day/decisions.md#ask-an-agent-for-a-recommendation) for the operator-facing behaviour.
+
 ---
 
 ## Where to go next


### PR DESCRIPTION
## What

`Ask agent for recommendation` shipped in `v2026.817.0` (`ui/src/components/DecisionTriageStrip.tsx`, commit [`8e7f1c03eb`](https://github.com/paperclipai/paperclip/commit/8e7f1c03eb), the squashed merge of [PR #10785](https://github.com/paperclipai/paperclip/pull/10785)) and was documented nowhere. Found while recapturing Decisions screenshots for the release blog baseline — the control was already visible in a shipped screenshot on this site with no prose explaining it.

Two changes:

1. **`docs/guides/day-to-day/decisions.md`** — a new `Ask an agent for a recommendation` section after the triage section, since the control lives in that same strip.
2. **`docs/reference/api/decisions.md`** — one blockquote in the Triage section clarifying that this strip control is *not* a Decisions route, so an integrator does not hunt for an endpoint that does not exist.

## The part that matters for the reader

The label reads like delegation, so the section is explicit that it is not. Selecting an agent posts **one mention-comment on the linked task** and nothing else. It does not reassign the task, does not answer or dismiss the decision, and does not touch the item's queues, decide-by target, or snooze. A reader can now predict exactly what happens before clicking.

Prerequisites are documented too: the item needs a linked task (budget alerts and join requests generally have none — verified, neither sets `relatedIssue` nor `metadata.issueId`, and their subject kinds are not `issue`), the company needs at least one agent that has not been terminated (that is the only filter on the list — paused and unapproved agents are offered, and are documented as not replying until resumed or approved), and the button settles while its own request is in flight.

**No new API capability is claimed.** The reference note names only the existing [Add Comment](https://docs.paperclip.ing/reference/api/issues#add-comment) route, which is what the control actually calls (`issuesApi.addComment`, no `reopen`/`interrupt`).

## Product truth — verified against the tag, not inferred

Every claim was read out of `git show v2026.817.0:...` rather than from the issue description:

- **Not feature-flagged.** `showTriage` is a hardcoded prop on `DecisionQueuePage.tsx:530`; `agents` comes from a plain `agentsApi.list(companyId)` query. No flag, env var, or config gate.
- **Disabled conditions** match `disabled={routeToAgent.isPending || !relatedIssueId}` plus `disabled={disabled || active.length === 0}` where `active = agents.filter(a => a.status !== "terminated")`.
- **Tooltip** `No linked task to ask about` and the success toast naming the agent are both quoted from source.
- **Strip visibility.** `triageEnabled = showTriage && !isHidden` with `isHidden = variant === "hidden"` — so the control is absent from dismissed/snoozed curtain rows. The section says so and tells you to restore the row first.

## Screenshot

No recapture needed. `light/decisions/triage-chips.png` already shows `Ask agent for recommendation` beside `Snooze` — it was accurate, just unexplained, and its alt text omitted the control. Alt text updated to match what the image shows.

## Verification

- `npm run sync:lint-links` — OK, 195 markdown files, no broken internal links.
- `npm run docs:build` — clean; 191 markdown files, 191 crawlable route pages.
- **Anchors checked by hand**, because the link linter strips fragments before resolving and would not have caught a bad one. Both confirmed present in built HTML: `id="add-comment"` in `.site/reference/api/issues/index.html` and `id="ask-an-agent-for-a-recommendation"` in `.site/guides/day-to-day/decisions/index.html`.
- `git diff --check` — clean.
- Rendered both changed sections out of the built HTML and read them once: headings, bold UI labels, bullets, blockquote, and all four links resolve as intended.

## Review round 2 — QA findings applied

Reviewed by QA ([evidence gallery](https://pages.paperclip.ing/pap-17785-qa/), 15 claims checked, 9 observed in the running app). No behavioural claim was falsified. Two fixes applied in `0ddd14eef`:

- **The picker list was described as the company's "active agents".** That is the one claim a reader could act on and be wrong about. The filter is only `status !== "terminated"` (`DecisionTriageStrip.tsx:438`), so on a live 51-agent desk 19 offered agents were paused or errored. The guide now says every non-terminated agent is offered, and calls out that paused and unapproved agents receive the comment but are not woken to act on it. QA's suggested wording grouped paused and errored agents together; I checked and `error` is *not* a blocked status — `DIRECT_NON_INVOKABLE_STATUSES` is `{paused, terminated, pending_approval}` and `heartbeat.ts:15511` cancels the run at execution-start for exactly those. An errored agent does get woken. The prose reflects the narrower, accurate set.
- **The no-linked-task examples were the ones a reader is least likely to meet.** On a live 180-item desk, every item with no linked task was an agent error alert; no budget alert or join request was present. Added agent alerts to the list.

Also re-derived independently rather than taking on report: `git merge-base --is-ancestor 8e7f1c03eb v2026.817.0` → ancestor; `252ec02ef5` → not in the tag. The `What` section above is corrected accordingly; no shipped doc cites a SHA.

Not changed, with reasons: the disabled-state tooltip is mouse-only (`title` attribute, no `aria-describedby`, and a disabled button is out of the tab order) — a real accessibility gap, but in the product, not this prose, so it is filed separately as [PAP-17788](https://app.paperclip.ing/PAP/issues/PAP-17788). The "does not move the item on the desk" sentence stays unhedged: `routeToAgent.mutationFn` is a single `issuesApi.addComment` call and the four triage mutations are each reachable only from their own control, so there is no code path from this button to queues, decide-by, or snooze.

Re-verified after the edits: `sync:lint-links` OK (195 files, no broken internal links), `docs:build` clean (191 files, 191 route pages), and the rendered section read once out of the built HTML.

## Coordination

[PAP-17784](https://github.com/paperclipai/paperclip-docs/pull/100) owned the adjacent stale API-only triage sentence and already merged. This branch is cut from `main` at `ebbab07ca` (that merge), touches no line it changed, and reuses the `When to decide` framing it introduced.

## Note for whoever owns release docs

`decisions.md` still carries `paperclip_version: v2026.720.0` while now documenting `v2026.817.0` behaviour. PR #95 (the v2026.817.0 release docs) and #100 both left it as-is, so I have not touched it rather than guess at a convention the release tooling may own. Flagging rather than fixing.

Refs PAP-17785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## QA round 2 — one more fix, in the round-1 replacement text

QA cleared both round-1 fixes at source and confirmed the `error`-status correction above was right. But the round-1 wording added a claim of its own that does not hold, and it is now fixed in `7e76e05d9`.

**The wording said** a paused or unapproved agent receives the comment "but is not woken to act on it **until you resume or approve them**." That tells the reader the request is parked and will be answered once they unpause. It will not be. Verified at `v2026.817.0` (`213dabab4f`) rather than from the report:

- The mention wake *is* created for the paused agent, then cancelled at execution start with `agent_not_invokable`.
- That code is the first entry of `NON_RETRYABLE_CONTINUATION_ERROR_CODES` (`recovery/service.ts:350-357`), and `recovery/service.pause-durability.test.ts` spec's it as non-retryable rather than leaving it incidental.
- `agents.resume()` (`services/agents.ts:662-683`) only sets `status: "idle"` and clears `pauseReason`/`errorReason`. Nothing re-enqueues the missed wake; the only `pendingWake`-shaped code paths in the server are cancellation and interaction checks, not replay.

The trap is that the adjacent `agent_paused` case behaves the opposite way — an agent paused *mid-run* does resume its work. Already-paused-when-asked takes the execution-start abort instead.

The section now says the request is not replayed, and tells the reader to resume or approve the agent first, then ask.

One correction to the round-1 note above: the execution-start gate is at `heartbeat.ts:15082-15095` at the tag, not `15511`.

**Side effect filed separately.** QA flagged, as unconfirmed, that a bounced mention-wake might reach `escalateStrandedAssignedIssue` and move the *linked task* to `blocked`. I traced it and it holds in code: `reconcileStrandedAssignedIssues` reads `latestRun` issue-scoped (`getLatestIssueRun`), the escalation branch never checks `latestRun.agentId` against the assignee (the adapter-failure branch directly above it does), and `escalateStrandedAssignedIssue` writes `status: "blocked"` without verifying its own `previousStatus`. Not reproduced live, so it is filed as a product question for the CTO in PAP-17790, not documented here. It does not gate this PR: no claim in the guide covers the linked task's status, and the new wording steers readers away from the trigger.

Re-verified after this edit: `sync:lint-links` OK (195 files, no broken internal links), `docs:build` clean (191 files, 191 route pages), and the section screenshotted once from the built site at 1280×900 — deep link lands on the heading and the new paragraph renders.

Refs PAP-17790.
