### PR TITLE
Emit real routes for in-article docs links so the site is crawlable (PAP-17913) [DRAFT]

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "docs:test:static-routes": "node scripts/verify-static-routes.mjs",
     "docs:test:asset-fingerprints": "node scripts/verify-asset-fingerprints.mjs",
     "docs:test:hierarchical-skills-nav": "node scripts/verify-hierarchical-skills-nav.mjs",
+    "docs:test:crawlable-link-graph": "node scripts/verify-crawlable-link-graph.mjs",
     "docs:test:skill-source-blocks": "node scripts/verify-skill-source-blocks.mjs",
     "docs:serve": "python3 -m http.server 4321 --directory .site",
     "sync:lint-links": "node scripts/sync/lint-links.mjs",

--- a/scripts/verify-crawlable-link-graph.mjs
+++ b/scripts/verify-crawlable-link-graph.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+/* PAP-17913 — the generated docs site must ship a crawlable internal link graph.
+ *
+ * Authors link sibling documents by relative markdown path. A document's HTML
+ * route is generated one directory deeper than its copied markdown, so those
+ * hrefs used to resolve one level too deep and 404 for anything reading the
+ * initial HTML — 1,283 of 1,283 same-origin in-article links were dead, and
+ * app.js was the only thing repairing them. Googlebot saw no followable path
+ * from any page to any other page.
+ *
+ * This check fails when an in-article same-origin link:
+ *   - ends in `.md`;
+ *   - resolves to no generated document (a 404);
+ *   - matches a redirect source, so following it costs a hop;
+ *   - points at a non-indexable resource (the `_headers` noindex extensions);
+ *   - disagrees with the destination document's own canonical URL.
+ *
+ * It also asserts the site makes no request for `/redirects.json`, which was a
+ * guaranteed 404 on every page load, and that the legacy slug map still reaches
+ * the client through content.json.
+ *
+ * Dangling *fragments* are reported as warnings rather than failures: the
+ * destination document still answers 200 and Google ignores fragments when
+ * indexing, and repointing an author's anchor is a content change that this
+ * PR deliberately keeps out of scope.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = process.cwd();
+const SITE_URL = "https://docs.paperclip.ing";
+const SUBPATH_BASE = "/paperclip-docs/";
+
+/* Extensions that `_headers` serves with `X-Robots-Tag: noindex, nofollow`.
+   An in-article link must never point a crawler at one of these. */
+const NON_INDEXABLE_EXTENSIONS = [
+  ".md", ".json", ".js", ".css", ".txt",
+  ".png", ".jpg", ".jpeg", ".webp", ".svg",
+];
+
+/* Markdown links that leave docs.paperclip.ing are legitimate — they point at
+   files in the product repo, not at docs routes. Only same-origin markdown
+   hrefs are the defect. This one is named in the ticket, so it is pinned as
+   proof the allowance is doing real work rather than swallowing everything. */
+const REQUIRED_EXTERNAL_MARKDOWN_LINK =
+  "https://github.com/paperclipai/paperclip/blob/main/CONTRIBUTING.md";
+
+/* The ticket's worked example, pinned so a regression is unmistakable. */
+const WORKED_EXAMPLE = {
+  route: "reference/cli/agent",
+  brokenHref: "./common-options.md",
+  expectedHref: "reference/cli/common-options",
+};
+
+const warnings = [];
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function buildRelease(basePath, targetDir) {
+  const build = spawnSync(process.execPath, [
+    "site/build-release.mjs", "--base-path", basePath, "--out-dir", targetDir,
+  ], { cwd: root, encoding: "utf8" });
+  assert(
+    build.status === 0,
+    `docs build failed for base path ${basePath}\nstdout:\n${build.stdout}\nstderr:\n${build.stderr}`,
+  );
+}
+
+function walkFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walkFiles(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+function articleHtml(html) {
+  return html.match(/<article id="article">([\s\S]*?)<\/article>/)?.[1] ?? null;
+}
+
+function canonicalOf(html) {
+  return html.match(/<link rel="canonical" data-seo-managed href="([^"]+)"/)?.[1] ?? null;
+}
+
+/* Every source path a `_redirects` rule would move. A link that matches one of
+   these costs the crawler a hop, which is what we are trying to eliminate. */
+function redirectSources(redirectsFile) {
+  const sources = new Set();
+  for (const line of redirectsFile.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const [source] = trimmed.split(/\s+/);
+    if (source) sources.add(source);
+  }
+  return sources;
+}
+
+function redirectRules(redirectsFile) {
+  const rules = [];
+  for (const line of redirectsFile.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const [source, destination, status] = trimmed.split(/\s+/);
+    rules.push({ source, destination, status, line: trimmed });
+  }
+  return rules;
+}
+
+function verifyBuild({ outDir, basePath, label }) {
+  const redirectsFile = readFileSync(join(outDir, "_redirects"), "utf8");
+  const sources = redirectSources(redirectsFile);
+  const rules = redirectRules(redirectsFile);
+  const htmlFiles = walkFiles(outDir).filter((file) => file.endsWith(".html"));
+  assert(htmlFiles.length > 100, `${label}: expected the full release, found ${htmlFiles.length} HTML files`);
+
+  /* ─── No same-origin `.md` href survives anywhere in the release ────────── */
+  let externalMarkdownLinks = 0;
+  let requiredExternalSeen = false;
+  for (const file of htmlFiles) {
+    const html = readFileSync(file, "utf8");
+    for (const match of html.matchAll(/href="([^"]*\.md(?:#[^"]*)?)"/g)) {
+      const href = match[1];
+      const docHref = href.split("#")[0];
+      if (docHref === REQUIRED_EXTERNAL_MARKDOWN_LINK) requiredExternalSeen = true;
+      const isOffSite = /^https?:\/\//i.test(docHref) && !docHref.startsWith(`${SITE_URL}/`);
+      if (isOffSite) {
+        externalMarkdownLinks += 1;
+        continue;
+      }
+      throw new Error(
+        `${label}: ${relative(outDir, file)} still ships a same-origin markdown href "${href}". ` +
+        "In-article links must be translated to their final HTML route at build time.",
+      );
+    }
+  }
+  assert(externalMarkdownLinks > 0, `${label}: no external markdown links found; this check is no longer exercised`);
+  assert(
+    requiredExternalSeen,
+    `${label}: the external link ${REQUIRED_EXTERNAL_MARKDOWN_LINK} disappeared — off-site markdown links must be left alone`,
+  );
+
+  /* ─── Every in-article link is a direct, indexable, self-canonical hit ──── */
+  const canonicalCache = new Map();
+  const idCache = new Map();
+  let checkedLinks = 0;
+  let danglingFragments = 0;
+  let workedExampleSeen = false;
+
+  for (const file of htmlFiles) {
+    const html = readFileSync(file, "utf8");
+    const article = articleHtml(html);
+    if (!article) continue;
+
+    for (const match of article.matchAll(/href="([^"]+)"/g)) {
+      const href = match[1];
+      if (/^[a-z]+:/i.test(href) || href.startsWith("//") || href.startsWith("#")) continue;
+      const where = `${label}: ${relative(outDir, file)} -> "${href}"`;
+      checkedLinks += 1;
+
+      assert(
+        href.startsWith(basePath),
+        `${where} is a same-origin link that does not start with the base path ${basePath}`,
+      );
+
+      const [docHref, fragment] = href.split("#");
+      const extension = docHref.replace(/\/$/, "").match(/\.[A-Za-z0-9]+$/)?.[0]?.toLowerCase();
+      assert(
+        !extension || !NON_INDEXABLE_EXTENSIONS.includes(extension),
+        `${where} points at a non-indexable resource (${extension} is noindex, nofollow in _headers)`,
+      );
+      assert(docHref.endsWith("/"), `${where} is missing its canonical trailing slash`);
+      /* Match the href exactly. Every route also has a no-slash -> slash 301,
+         so stripping the trailing slash here would flag every correct link. */
+      assert(
+        !sources.has(docHref),
+        `${where} matches a redirect source, so following it costs a hop instead of landing directly`,
+      );
+
+      const target = join(outDir, docHref.slice(basePath.length), "index.html");
+      assert(existsSync(target), `${where} resolves to a 404 — no document is generated there`);
+
+      if (!canonicalCache.has(target)) {
+        const targetHtml = readFileSync(target, "utf8");
+        canonicalCache.set(target, canonicalOf(targetHtml));
+        idCache.set(target, new Set([...targetHtml.matchAll(/\bid="([^"]+)"/g)].map((m) => m[1])));
+      }
+      const canonical = canonicalCache.get(target);
+      assert(canonical, `${where} lands on a document with no managed canonical`);
+      assert(
+        canonical === `${SITE_URL}${docHref}`,
+        `${where} disagrees with the destination canonical (${canonical})`,
+      );
+
+      if (fragment && !idCache.get(target).has(decodeURIComponent(fragment))) {
+        danglingFragments += 1;
+        warnings.push(`${where} keeps a fragment "#${fragment}" that the destination does not define`);
+      }
+
+      if (
+        relative(outDir, file) === join(WORKED_EXAMPLE.route, "index.html") &&
+        docHref === `${basePath}${WORKED_EXAMPLE.expectedHref}/`
+      ) {
+        workedExampleSeen = true;
+      }
+    }
+  }
+
+  assert(checkedLinks > 1000, `${label}: only ${checkedLinks} in-article links checked; the crawl expected the full set`);
+  assert(
+    workedExampleSeen,
+    `${label}: /${WORKED_EXAMPLE.route}/ no longer links to /${WORKED_EXAMPLE.expectedHref}/ ` +
+    `(the ticket's worked example, previously "${WORKED_EXAMPLE.brokenHref}")`,
+  );
+
+  /* ─── Links must not need JavaScript ───────────────────────────────────── */
+  const exampleFile = join(outDir, WORKED_EXAMPLE.route, "index.html");
+  const exampleArticle = articleHtml(readFileSync(exampleFile, "utf8"));
+  assert(
+    exampleArticle?.includes(`href="${basePath}${WORKED_EXAMPLE.expectedHref}/"`),
+    `${label}: the worked example's link must live in the server-rendered <article>, not be built by app.js`,
+  );
+
+  /* ─── /redirects.json must not be requested, and its data must survive ─── */
+  for (const file of walkFiles(outDir)) {
+    if (!/\.(?:html|js)$/.test(file)) continue;
+    assert(
+      !readFileSync(file, "utf8").includes("redirects.json"),
+      `${label}: ${relative(outDir, file)} still references redirects.json, which is never deployed and always 404s`,
+    );
+  }
+  assert(
+    !existsSync(join(outDir, "redirects.json")),
+    `${label}: redirects.json was deployed; the legacy map belongs in content.json and _redirects`,
+  );
+  const legacyRedirects = JSON.parse(readFileSync(join(root, "site/redirects.json"), "utf8"));
+  const manifest = JSON.parse(readFileSync(join(outDir, "content.json"), "utf8"));
+  assert(
+    manifest.redirects && typeof manifest.redirects === "object",
+    `${label}: content.json is missing the legacy redirect map, so ?page= and #/slug routes break`,
+  );
+  for (const [from, to] of Object.entries(legacyRedirects)) {
+    assert(
+      manifest.redirects[from] === to,
+      `${label}: content.json lost the legacy mapping ${from} -> ${to}`,
+    );
+  }
+  assert(
+    Object.keys(manifest.redirects).length === Object.keys(legacyRedirects).length,
+    `${label}: content.json redirect map does not match site/redirects.json exactly`,
+  );
+
+  /* ─── Redirects stay explicit, one-hop, and destination-relevant ───────── */
+  for (const { source, destination, status, line } of rules) {
+    assert(!source.includes("*"), `${label}: broad redirect rule introduced: ${line}`);
+    assert(status === "301", `${label}: redirect must be a one-hop 301: ${line}`);
+    assert(
+      !sources.has(destination),
+      `${label}: redirect chains through another redirect: ${line}`,
+    );
+    assert(
+      existsSync(join(outDir, destination.slice(basePath.length), "index.html")) ||
+        destination === basePath,
+      `${label}: redirect destination does not exist: ${line}`,
+    );
+  }
+
+  return { checkedLinks, externalMarkdownLinks, danglingFragments, htmlFiles: htmlFiles.length };
+}
+
+const outDir = mkdtempSync(join(tmpdir(), "paperclip-docs-link-graph-"));
+const subpathOutDir = mkdtempSync(join(tmpdir(), "paperclip-docs-link-graph-subpath-"));
+
+try {
+  buildRelease("/", outDir);
+  const rootResult = verifyBuild({ outDir, basePath: "/", label: "root build" });
+
+  buildRelease(SUBPATH_BASE, subpathOutDir);
+  const subpathResult = verifyBuild({
+    outDir: subpathOutDir,
+    basePath: SUBPATH_BASE,
+    label: `${SUBPATH_BASE} build`,
+  });
+
+  assert(
+    rootResult.checkedLinks === subpathResult.checkedLinks,
+    `the subpath build checked ${subpathResult.checkedLinks} in-article links but the root build checked ${rootResult.checkedLinks}`,
+  );
+
+  /* Dangling fragments are reported, never silently dropped. */
+  if (warnings.length > 0) {
+    console.warn(
+      `\n${warnings.length} non-fatal warning(s) — destination documents answer 200, but these author anchors do not exist:`,
+    );
+    for (const warning of [...new Set(warnings)]) console.warn(`- ${warning}`);
+    console.warn("");
+  }
+
+  console.log(
+    `Crawlable link graph verified: ${rootResult.checkedLinks} in-article links per build ` +
+    `across ${rootResult.htmlFiles} documents, 0 markdown hrefs, ` +
+    `${rootResult.externalMarkdownLinks} allowed external markdown links, ` +
+    `no redirect hops, no redirects.json request (root and ${SUBPATH_BASE} builds).`,
+  );
+} finally {
+  rmSync(outDir, { recursive: true, force: true });
+  rmSync(subpathOutDir, { recursive: true, force: true });
+}

--- a/site/app.js
+++ b/site/app.js
@@ -307,6 +307,19 @@ function slugifyHeadingText(text) {
     .replace(/-+/g, '-');
 }
 
+/* Strip the deployment base path off a same-origin href so it can be matched
+   against a nav slug. Returns '' for anything outside this bundle's base path. */
+function routeKeyFromHref(href) {
+  let pathname;
+  try {
+    pathname = new URL(href, window.location.href).pathname;
+  } catch {
+    return '';
+  }
+  if (!pathname.startsWith(APP_BASE_PATH)) return '';
+  return normalizeRouteKey(pathname.slice(APP_BASE_PATH.length)).replace(/\/index\.html$/, '');
+}
+
 function findPageByRoute(route) {
   const decoded = decodeURIComponent((route || '').trim());
   const normalizedRoute = normalizeRouteKey(decoded);
@@ -848,6 +861,11 @@ function initSearch() {
 }
 
 /* ─── Boot ──────────────────────────────────────────────────────────────── */
+/* Legacy path routes are 301'd by Cloudflare (_redirects) before this script
+   ever boots. This map only exists for the two legacy shapes a server cannot
+   see: the `?page=` query route and the `#/slug` hash route. It ships inside
+   content.json rather than as its own redirects.json request, which used to
+   404 on every page load (PAP-17913). */
 let redirectMap = {};
 
 function applyRedirect(route) {
@@ -872,11 +890,10 @@ async function init() {
     return;
   }
 
-  // Optional: load redirect map for moved pages (old → new slug).
-  try {
-    const rRes = await fetch(resolveContentUrl('redirects.json'));
-    if (rRes.ok) redirectMap = await rRes.json();
-  } catch { /* no redirects file is fine */ }
+  // Redirect map for moved pages (old → new slug), carried by the manifest.
+  if (navData.redirects && typeof navData.redirects === 'object') {
+    redirectMap = navData.redirects;
+  }
 
   buildFlatList();
   buildLanding();
@@ -1636,6 +1653,10 @@ function postProcessInternalLinks(root) {
     }
 
     const [docHref, headingHref] = href.split('#');
+
+    // Released documents ship final route hrefs (PAP-17913). Client-rendered
+    // markdown still carries author-relative `.md` paths, so both shapes are
+    // resolved back to a nav page and navigated without a full reload.
     if (docHref && docHref.endsWith('.md')) {
       const baseDir = currentFile.replace(/\/[^/]+$/, '/');
       const targetFile = normalizeDocPath(baseDir + docHref);
@@ -1646,6 +1667,16 @@ function postProcessInternalLinks(root) {
       a.addEventListener('click', e => {
         e.preventDefault();
         loadPage(targetFile, headingHref || null);
+      });
+      return;
+    }
+
+    const routePage = docHref ? findPageByRoute(routeKeyFromHref(docHref)) : null;
+    if (routePage) {
+      a.addEventListener('click', e => {
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+        e.preventDefault();
+        loadPage(routePage.file, headingHref || null);
       });
     }
   });

--- a/site/build-release.mjs
+++ b/site/build-release.mjs
@@ -993,7 +993,53 @@ function isSkillSourceInfo(infostring) {
   return String(infostring || "").trim().split(/\s+/).includes("skill-source");
 }
 
-export function renderStaticMarkdown(markdown) {
+/* ─── Crawlable in-article link graph (PAP-17913) ─────────────────────────
+   Authors link sibling documents by relative markdown path (`./common-options.md`).
+   A document's HTML route lives one directory deeper than its copied markdown
+   (`/reference/cli/agent/index.html` vs `/reference/cli/agent.md`), so those
+   author-relative hrefs resolve one level too deep and 404 for anything that
+   reads the initial HTML. app.js repairs them at runtime, which leaves the link
+   graph invisible to a crawler and to a JavaScript-disabled reader.
+
+   Translate every same-origin `.md` link into its canonical trailing-slash
+   route during generation, using the same content.json manifest that already
+   feeds the sidebar, the homepage directory, prev/next, and the sitemap. */
+
+function buildDocRouteManifest(nav, basePath) {
+  const routesByDocPath = new Map();
+  for (const { page } of flattenNavPages(nav)) {
+    routesByDocPath.set(path.resolve(docsRoot, page.file), routePathForSlug(basePath, page.slug));
+  }
+  return routesByDocPath;
+}
+
+/* Resolve an author-relative markdown href from `sourceFile` into its final
+   route. Returns null for anything that is not a same-origin `.md` link so the
+   caller can leave it untouched, and throws when a `.md` link has no route —
+   silently shipping such an href is the exact defect this replaces. */
+function createDocLinkResolver({ routesByDocPath, sourceFile }) {
+  const sourceDir = path.dirname(path.resolve(docsRoot, sourceFile));
+  return (href) => {
+    if (typeof href !== "string" || !isLocalDocHref(href)) return null;
+    const hashIndex = href.indexOf("#");
+    const docHref = hashIndex === -1 ? href : href.slice(0, hashIndex);
+    const fragment = hashIndex === -1 ? "" : href.slice(hashIndex);
+    if (!docHref.endsWith(".md")) return null;
+
+    const targetPath = path.resolve(sourceDir, docHref);
+    const route = routesByDocPath.get(targetPath);
+    if (!route) {
+      throw new Error(
+        `Unroutable in-article link in ${sourceFile}: "${href}" resolves to ` +
+        `${toPosixPath(path.relative(repoRoot, targetPath))}, which has no route in content.json. ` +
+        "Add the document to the nav manifest or point the link at a document that is in it.",
+      );
+    }
+    return `${route}${fragment}`;
+  };
+}
+
+export function renderStaticMarkdown(markdown, { resolveDocLink = null } = {}) {
   const renderer = new marked.Renderer();
   const usedHeadingIds = new Set();
   renderer.image = releaseMarkdownImage;
@@ -1004,6 +1050,10 @@ export function renderStaticMarkdown(markdown) {
     }
     return defaultCode(code, infostring, escaped);
   };
+  // Emit the final route for same-origin markdown links so the server-rendered
+  // HTML carries a followable link graph with no client JavaScript (PAP-17913).
+  const defaultLink = renderer.link.bind(renderer);
+  renderer.link = (href, title, text) => defaultLink(resolveDocLink?.(href) ?? href, title, text);
   renderer.heading = (html, level, rawText) => {
     const baseId = slugifyHeadingText(rawText) || `h${level}`;
     let id = baseId;
@@ -1215,8 +1265,8 @@ function buildStaticPageNav(prev, next) {
   return `${prevHtml}${nextHtml}`;
 }
 
-function buildStaticPageHtml(sourceIndex, metadata, markdown, basePath, releaseStyles, prev, next) {
-  const articleHtml = renderStaticMarkdown(markdown);
+function buildStaticPageHtml(sourceIndex, metadata, markdown, basePath, releaseStyles, prev, next, resolveDocLink) {
+  const articleHtml = renderStaticMarkdown(markdown, { resolveDocLink });
   const routeBaseHref = getPublicBasePath(basePath);
   return removeLandingSubtree(
     inlineReleaseStyles(injectSeo(sourceIndex, metadata, { baseHref: routeBaseHref }), releaseStyles),
@@ -1229,9 +1279,10 @@ function buildStaticPageHtml(sourceIndex, metadata, markdown, basePath, releaseS
     );
 }
 
-async function writeStaticRoutePages({ outDir, sourceIndex, pages, markdownBodiesByFile, basePath, releaseStyles }) {
+async function writeStaticRoutePages({ outDir, sourceIndex, pages, markdownBodiesByFile, basePath, releaseStyles, routesByDocPath }) {
   for (const [index, metadata] of pages.entries()) {
     const { page } = metadata;
+    const resolveDocLink = createDocLinkResolver({ routesByDocPath, sourceFile: page.file });
     const markdown = markdownBodiesByFile.get(page.file);
     if (!markdown) continue;
     const routePath = path.join(outDir, ...page.slug.split("/"), "index.html");
@@ -1249,6 +1300,7 @@ async function writeStaticRoutePages({ outDir, sourceIndex, pages, markdownBodie
         releaseStyles,
         pages[index - 1],
         pages[index + 1],
+        resolveDocLink,
       ),
     );
   }
@@ -1374,6 +1426,12 @@ async function main() {
     const fm = frontmatterByFile.get(page.file);
     if (fm) page.frontmatter = fm;
   }
+  // The legacy slug map ships inside the manifest the client already fetches.
+  // It used to be a separate redirects.json request that was never copied into
+  // the release, so every page load spent a 404 on it (PAP-17913). Cloudflare
+  // `_redirects` still owns legacy *path* routes; this copy exists only for the
+  // `?page=` and `#/slug` shapes a server never sees.
+  releaseNav.redirects = sourceRedirects;
   await fs.writeFile(path.join(options.outDir, "content.json"), `${JSON.stringify(releaseNav)}\n`);
 
   const pageMetadata = await pageMetadataForNav(releaseNav, options.outDir, options.siteUrl, options.basePath);
@@ -1403,6 +1461,7 @@ async function main() {
     markdownBodiesByFile,
     basePath: options.basePath,
     releaseStyles,
+    routesByDocPath: buildDocRouteManifest(releaseNav, options.basePath),
   });
 
   await fs.writeFile(path.join(options.outDir, "sitemap.xml"), buildSitemap({


### PR DESCRIPTION
Draft PR B of the docs.paperclip.ing indexing remediation sequence authorised on PAP-17873. Tracked by PAP-17913.

**Draft on purpose. Do not merge, do not deploy.** Merge and deploy need separate explicit approval from Dotta.

## The defect

docs.paperclip.ing has 0 of 184 submitted URLs indexed. 170 of them are `Discovered – currently not indexed` and have never been crawled, with no referring page detected. Index *eligibility* is fine — pages are `index, follow` with self-referential canonicals and recent successful crawls. What was missing was crawl *discovery*: the generated site shipped no followable internal link graph.

Authors link sibling documents by relative markdown path (`./common-options.md`). A document's HTML route is generated one directory deeper than its copied markdown (`/reference/cli/agent/index.html` vs `/reference/cli/agent.md`), so every author-relative href resolved one level too deep and 404'd. `site/app.js` repaired them at runtime, which kept the site usable for humans and left the link graph invisible to a crawler and to anyone with JavaScript off.

Measured on `main` (`ebbab07ca`), root build:

| | Before | After |
| --- | --- | --- |
| Same-origin `.md` hrefs in generated HTML | **1,283** | **0** |
| ...resolving to a file that exists in the release | 0 | n/a |
| ...resolving to a 404 | **1,283** | **0** |
| In-article same-origin links resolving to a generated route | 0 | **1,287** |
| External `github.com` `.md` links (left alone) | 193 | 193 |
| Redirect hops on in-article links | n/a | 0 |
| `/redirects.json` requests per page load | 1 (always 404) | 0 |

The failure rate was 100% of same-origin in-article links, not "most".

## What changed

**`site/build-release.mjs`**
- `buildDocRouteManifest()` builds doc-path → canonical trailing-slash route from the same `content.json` manifest that already feeds the sidebar, homepage directory, prev/next, and sitemap.
- `createDocLinkResolver()` resolves an author-relative `.md` href against the source document and returns the final route, preserving the fragment verbatim: `../../../skills.md#3-app-shipped-catalog` → `/reference/skills/#3-app-shipped-catalog`.
- `renderStaticMarkdown()` takes an optional `resolveDocLink` and overrides `marked`'s `renderer.link`, so the translation happens in the server-rendered HTML with no client JavaScript. Tab blocks are covered by the same renderer.
- An unroutable `.md` link now **fails the build** with the source file, the href, and the resolved path. All 1,283 links resolve against the manifest today (zero off-manifest), so there is no orphan tail this degrades.
- The legacy slug map is merged into `content.json` instead of being fetched separately.

**`site/app.js`**
- Released documents now carry final route hrefs, so `postProcessInternalLinks()` resolves those back to a nav page via the new `routeKeyFromHref()` helper and keeps navigation client-side. The `.md` branch stays for client-rendered markdown, and modifier-clicks / middle-clicks fall through to the browser.
- Dropped the `fetch('redirects.json')` — see below.

**`scripts/verify-crawlable-link-graph.mjs`** + `npm run docs:test:crawlable-link-graph` (new)

Follows the `scripts/verify-static-routes.mjs` pattern: builds both bundles into temp dirs and crawls every generated document. Fails on any in-article same-origin link that:

- ends in `.md`;
- resolves to no generated document (404);
- matches a `_redirects` source, so following it costs a hop;
- targets a non-indexable resource (the `_headers` `noindex, nofollow` extensions);
- disagrees with the destination document's own `<link rel="canonical">`;
- is missing its canonical trailing slash.

It also asserts redirects stay explicit and one-hop (no `/*` rule, every rule a 301, no chains, every destination a real route), that off-site markdown links are preserved, that the ticket's worked example is in the server-rendered `<article>`, and that both builds check an identical link count. It reports dangling fragments as warnings rather than silently dropping them.

## `/redirects.json` — traced, not guessed

`/redirects.json` was a guaranteed 404 on every page load. Three findings decided the fix:

1. `site/redirects.json` is **already** compiled into the deployed `_redirects` at build time via `buildCloudflareRedirects({ legacyRedirects })`, and `verify-static-routes.mjs` already asserts every legacy entry is a one-hop 301 there. Legacy **path** routes never needed the runtime file.
2. The only consumer was an optional `fetch()` in `app.js:877`, already wrapped in `try/catch` with the comment *"no redirects file is fine"*.
3. But the map is **not** dead. `getLegacyRoute()` also handles `?page=<slug>` and `#/<slug>` — a query route and a fragment route that Cloudflare `_redirects` cannot match. Those genuinely still need a client-side map.

So neither "just delete the request" nor "deploy the file" is right. The map now ships **inside `content.json`**, which the client already fetches: the 404 disappears, no new request is added, and legacy `?page=` / `#/slug` navigation is preserved. Both legacy shapes are verified working in a real browser below. The test asserts `content.json`'s map matches `site/redirects.json` exactly, so the two cannot drift.

No new redirect rules were introduced, and production redirects, robots, canonicals, sitemaps, CDN and caching settings are untouched.

## Verification

This repo has **no GitHub Actions CI** — these ran locally and nowhere else. Commit under test: `99e3ad1937dae5f72153dfafb42fc3f60944dec2`.

```
$ npm run docs:test:crawlable-link-graph
Crawlable link graph verified: 1287 in-article links per build across 193 documents,
0 markdown hrefs, 193 allowed external markdown links, no redirect hops,
no redirects.json request (root and /paperclip-docs/ builds).
(+ 18 non-fatal warnings — see "Known issues" below)

$ npm run docs:test:static-routes
Static route verification passed (5 representative routes + /guides/welcome/this-route-does-not-exist/, root and /paperclip-docs/ builds).

$ npm run docs:test:asset-fingerprints
Asset fingerprint verification passed (bundle app.1a67afe85f24.js, 1 bundle, headers checked).

$ npm run docs:test:hierarchical-skills-nav
Hierarchical Skills nav verification passed.

$ npm run sync:lint-links
OK — 195 markdown files, no broken internal links.

$ npm run sync:test
Results: 37 passed, 0 failed.
```

### Real-browser check, JavaScript on and off

Both bundles served over HTTP and driven with headless Chromium — **28/28 checks passed**:

| Check | root build | `/paperclip-docs/` build |
| --- | --- | --- |
| no-JS: zero `.md` hrefs in article (13 links) | PASS | PASS |
| no-JS: article links to the correct route | PASS | PASS |
| no-JS: following the link is a direct 200, 1 hop | PASS | PASS |
| no-JS: destination renders its own H1 | PASS | PASS |
| no-JS: fragment target `#3-app-shipped-catalog` exists | PASS | PASS |
| no-JS: no `/redirects.json` request | PASS | PASS |
| JS: in-article click renders the destination | PASS | PASS |
| JS: URL updates to the canonical route | PASS | PASS |
| JS: navigation stays client-side (document sentinel survives) | PASS | PASS |
| JS: no same-origin 4xx/5xx requests | PASS | PASS |
| JS: legacy `?page=user-guides/guides/skills` resolves | PASS | PASS |
| JS: legacy `#/user-guides/guides/skills` resolves | PASS | PASS |

The only 4xx observed anywhere was `https://api.github.com/repos/paperclipai/paperclip` → 403, a pre-existing external star-count fetch that this host is rate-limited on. Unrelated to this change.

### Draft PR A compatibility

Trial-merged `origin/pap-17873-sitemap-lastmod-honesty` (PR #104) into this branch and ran both suites on the merge commit — no conflicts, all green including PR A's own `docs:test:sitemap-lastmod-history`. This PR is based on `main`, so PR A's test script is not present here yet; whichever lands second needs no rebase. (Note for reviewers: PR A's test builds from a fresh clone of `HEAD`, so it must be run on a *committed* merge — an uncommitted trial merge makes it fail spuriously.)

## Known issues, deliberately not fixed here

`docs:test:skill-source-blocks` fails identically on `main` (`docs/reference/skills/optional/content/simplified-english.md`: expected one skill-source block, found 0). Confirmed against a clean `main` worktree at `ebbab07ca`. Pre-existing, out of scope, not a blocker.

The new check reports **9 dangling author fragments** (18 warnings = 9 × both builds) as non-fatal. These were invisible before because the whole link was broken. Two classes:

- **6 links** use GitHub's anchor convention, which keeps double hyphens, while the site collapses `-+` to `-`: e.g. `#recommended-bundle-structure-agents--soul--heartbeat--tools` vs the generated `...agents-soul-heartbeat-tools`.
- **3 links** point at renamed or renumbered headings: `#m`, `#4-scoping-rules`, `#3-assigning-skills-to-agents`, `#8-troubleshooting-why-a-skill-isnt-loading`.

Kept as warnings, not failures: the destination document still answers 200, Google ignores fragments when indexing, and repointing an author's anchor is a content change this PR deliberately keeps out of scope. Filed as a follow-up.

## Risks and rollback

- **Risk: a future doc links to a page that is not in `content.json`.** The build now fails instead of shipping a 404. Two orphan files exist on disk today (`docs/reference/cli/commands.md`, `docs/reference/cli/control-plane-commands.md`, both already reported by `sync:verify-nav` on `main`), and nothing links to them — but a link to either would break the build with a clear message. That is the intended trade: loud at build time beats silent in production.
- **Risk: client navigation regression.** Interception now keys on route hrefs rather than `.md` paths. Covered by the JS-enabled browser checks above; modifier and middle clicks are explicitly passed through to the browser.
- **Risk: `content.json` grows** by the 93-entry redirect map. It is served `must-revalidate` alongside the HTML and was already fetched on every page load, so this replaces a request rather than adding bytes to a new one.
- **Stop condition:** if a post-deploy crawl shows any in-article link 404ing or redirecting, stop and roll back — the check should have caught it, so a miss means the check has a gap.
- **Rollback target:** `ebbab07ca` (current `main`). This is a single revertable commit touching only the generator, the client bundle, and a new test; no data migration, no production config.

## Not done, by design

Kept out per scope isolation: the sitemap `lastmod` fix (PR A, #104), internal-linking and authority work (PR C), content rewrites, title changes, and navigation redesign. No Google Search Console action was taken — no resubmission, no indexing request, no fix validation, no URL removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
