### PR TITLE
Point 9 dangling in-article anchors at heading ids that exist (PAP-17915)

### DIFF
--- a/docs/guides/day-to-day/issues.md
+++ b/docs/guides/day-to-day/issues.md
@@ -664,7 +664,7 @@ You now know how to create, assign, track, triage, and close issues. The next gu
 
 ## Appendix — Issue workflow patterns (for agent developers)
 
-If you're building an agent or adapter, here are the patterns your agent should follow when operating on issues. These sit on top of the [heartbeat protocol](../projects-workflow/routines.md#appendix--the-heartbeat-protocol-for-agent-developers).
+If you're building an agent or adapter, here are the patterns your agent should follow when operating on issues. These sit on top of the [heartbeat protocol](../projects-workflow/routines.md#appendix-the-heartbeat-protocol-for-agent-developers).
 
 ### Checkout pattern
 

--- a/docs/guides/welcome/glossary.md
+++ b/docs/guides/welcome/glossary.md
@@ -106,6 +106,14 @@ Another word for Task (used interchangeably in the API and some parts of the UI)
 
 ---
 
+## M
+
+### MCP (Model Context Protocol)
+
+An open standard for connecting language-model runtimes to external tools and data sources over a small JSON-RPC contract. Paperclip itself does not speak MCP — the adapter launches the runtime, and the runtime is what connects to MCP servers. Paperclip's job is to scope which agent gets which adapter config, and to surface the resulting tool list in the run viewer. See [Add an MCP server to an agent's toolkit](../../how-to/add-mcp-server-to-agent.md).
+
+---
+
 ## O
 
 ### Org chart

--- a/docs/how-to/add-mcp-server-to-agent.md
+++ b/docs/how-to/add-mcp-server-to-agent.md
@@ -8,7 +8,7 @@ The mental model is unchanged: Paperclip is the control plane, the adapter launc
 
 ## What MCP is
 
-[Model Context Protocol](https://modelcontextprotocol.io) (see also: [glossary](../guides/welcome/glossary.md)) is an open standard for connecting language-model runtimes to external tools and data sources over a small JSON-RPC contract. An MCP server exposes a set of tools (and optionally resources and prompts) over `stdio` (local) or HTTP/SSE (remote). An MCP-aware runtime — like Claude Code or Hermes Agent — lists those tools and lets the agent call them mid-run.
+[Model Context Protocol](https://modelcontextprotocol.io) (see also: [glossary entry](../guides/welcome/glossary.md#mcp-model-context-protocol)) is an open standard for connecting language-model runtimes to external tools and data sources over a small JSON-RPC contract. An MCP server exposes a set of tools (and optionally resources and prompts) over `stdio` (local) or HTTP/SSE (remote). An MCP-aware runtime — like Claude Code or Hermes Agent — lists those tools and lets the agent call them mid-run.
 
 For Paperclip, MCP is how you give an agent a capability that doesn't fit a [skill](../reference/skills.md) (which is a markdown bundle, not executable) and that you don't want to teach the agent to call as raw HTTP. If the tool already speaks MCP, prefer that path.
 

--- a/docs/how-to/add-mcp-server-to-agent.md
+++ b/docs/how-to/add-mcp-server-to-agent.md
@@ -8,7 +8,7 @@ The mental model is unchanged: Paperclip is the control plane, the adapter launc
 
 ## What MCP is
 
-[Model Context Protocol](https://modelcontextprotocol.io) (see also: [glossary entry](../guides/welcome/glossary.md#m)) is an open standard for connecting language-model runtimes to external tools and data sources over a small JSON-RPC contract. An MCP server exposes a set of tools (and optionally resources and prompts) over `stdio` (local) or HTTP/SSE (remote). An MCP-aware runtime — like Claude Code or Hermes Agent — lists those tools and lets the agent call them mid-run.
+[Model Context Protocol](https://modelcontextprotocol.io) (see also: [glossary](../guides/welcome/glossary.md)) is an open standard for connecting language-model runtimes to external tools and data sources over a small JSON-RPC contract. An MCP server exposes a set of tools (and optionally resources and prompts) over `stdio` (local) or HTTP/SSE (remote). An MCP-aware runtime — like Claude Code or Hermes Agent — lists those tools and lets the agent call them mid-run.
 
 For Paperclip, MCP is how you give an agent a capability that doesn't fit a [skill](../reference/skills.md) (which is a markdown bundle, not executable) and that you don't want to teach the agent to call as raw HTTP. If the tool already speaks MCP, prefer that path.
 

--- a/docs/how-to/connect-agent-to-github.md
+++ b/docs/how-to/connect-agent-to-github.md
@@ -170,7 +170,7 @@ This means a task worded like *"Fix the null org id crash, then open a pull requ
 
 ## 4. The agent instructions: PR-driven work
 
-The agent's `AGENTS.md` is what turns "do the task" into "do the task on a branch and open a PR". You don't need a special template — you need three rules in the entry file that the agent reads on every heartbeat. See [Agents → Recommended bundle structure](../guides/org/agents.md#recommended-bundle-structure-agents--soul--heartbeat--tools) for the full bundle layout; this snippet drops into the working-rules section of `AGENTS.md` for any coder role.
+The agent's `AGENTS.md` is what turns "do the task" into "do the task on a branch and open a PR". You don't need a special template — you need three rules in the entry file that the agent reads on every heartbeat. See [Agents → Recommended bundle structure](../guides/org/agents.md#recommended-bundle-structure-agents-soul-heartbeat-tools) for the full bundle layout; this snippet drops into the working-rules section of `AGENTS.md` for any coder role.
 
 ```md
 ## Working rules: PR-driven
@@ -274,7 +274,7 @@ For deeper heartbeat-level debugging — the agent isn't waking, the heartbeat f
 ## See also
 
 - [Workspaces](../guides/projects-workflow/workspaces.md) — full reference for `cwd`, `repoUrl`, `branchName`, and worktree lifecycle.
-- [Agents → Recommended bundle structure](../guides/org/agents.md#recommended-bundle-structure-agents--soul--heartbeat--tools) — how `AGENTS.md` works alongside `SOUL.md`, `HEARTBEAT.md`, and `TOOLS.md`.
+- [Agents → Recommended bundle structure](../guides/org/agents.md#recommended-bundle-structure-agents-soul-heartbeat-tools) — how `AGENTS.md` works alongside `SOUL.md`, `HEARTBEAT.md`, and `TOOLS.md`.
 - [Claude Code](../reference/adapters/claude-code.md) — adapter fields, env vars, and session persistence.
 - [Codex](../reference/adapters/codex.md) — same recipe, OpenAI's Codex CLI instead.
 - [Execution Policy](../guides/power/execution-policy.md) — staged review with named participants.

--- a/docs/how-to/require-board-approval-before-spend.md
+++ b/docs/how-to/require-board-approval-before-spend.md
@@ -233,7 +233,7 @@ Two important details about the wake:
 - **The wake covers `approved` and `rejected` only.** `request-revision` does not fire `PAPERCLIP_APPROVAL_ID`. The board's `decisionNote` is stored on the approval; the agent learns about it on its next normal heartbeat (or sooner if you also leave a comment on the source issue, which *does* fire a wake — see [Debug a stuck heartbeat](./debug-stuck-heartbeat.md) for the full set of wake reasons).
 - **Re-fetch the approval and the linked issues.** The env vars only carry the id and the verdict. The payload, the `decisionNote`, and the linked-issue list all live on the API and may have changed since the agent submitted the request — particularly after a revision round.
 
-For BYO-agent runtimes that don't get Paperclip-driven wakes at all (the polling pattern in [Bring your own agent → Option C](./bring-your-own-agent.md#option-c--custom-script-no-paperclip-adapter)), poll the approval directly: `GET /api/approvals/$APPROVAL_ID` returns the current status. Loop with backoff and bail when `status != "pending"`.
+For BYO-agent runtimes that don't get Paperclip-driven wakes at all (the polling pattern in [Bring your own agent → Option C](./bring-your-own-agent.md#option-c-custom-script-no-paperclip-adapter)), poll the approval directly: `GET /api/approvals/$APPROVAL_ID` returns the current status. Loop with backoff and bail when `status != "pending"`.
 
 ---
 

--- a/docs/how-to/write-a-company-skill.md
+++ b/docs/how-to/write-a-company-skill.md
@@ -174,7 +174,7 @@ curl "$PAPERCLIP_API_URL/api/agents/$CODER_AGENT_ID/skills" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY"
 ```
 
-The response (an `AgentSkillSnapshot`) lists every entry the agent currently has, with `state` (`configured`, `installed`, `available`, etc.) and `mode` (the runtime sync strategy — see below). The full schema is at [Skills reference → Assigning skills to agents](../reference/skills.md#3-assigning-skills-to-agents).
+The response (an `AgentSkillSnapshot`) lists every entry the agent currently has, with `state` (`configured`, `installed`, `available`, etc.) and `mode` (the runtime sync strategy — see below). The full schema is at [Skills reference → Assigning skills to agents](../reference/skills.md#4-assigning-skills-to-agents).
 
 Each `desiredSkills` entry can be:
 
@@ -255,7 +255,7 @@ On the agent's next heartbeat, open its run viewer (**Agents → `<agent>` → R
 - the `SKILL.md` body in the run's tool/context output, or
 - the agent's response visibly following the skill's section order and voice rules.
 
-If neither is true, walk down the troubleshooting checklist in the [Skills reference](../reference/skills.md#8-troubleshooting-why-a-skill-isnt-loading). The two most common failures: the routing description is too vague for the agent to match, or the adapter's sync mode is `unsupported`.
+If neither is true, walk down the troubleshooting checklist in the [Skills reference](../reference/skills.md#9-troubleshooting-why-a-skill-isnt-loading). The two most common failures: the routing description is too vague for the agent to match, or the adapter's sync mode is `unsupported`.
 
 > **Tightening the description is the lever, not the body.** If the agent doesn't load the skill when it should, the body is rarely the problem. Rewrite the `description` to name the trigger more concretely ("Use when the user asks for *release notes* or a *changelog*…"). The body only matters once the skill is actually loaded.
 
@@ -313,7 +313,7 @@ Local-path skills aren't pinned, so they don't expose `update-status` — the re
 - **Bundled skills are forced on.** `paperclipai/paperclip/*` skills are unioned into every resolved set; you can't drop them.
 - **Adapter sync mode is the runtime gate.** If `mode: "unsupported"`, the assignment exists but no files reach the runtime. Either switch adapters or manage skills in the remote runtime.
 
-The full set of rules — required vs. optional, bundled-required, materialisation strategy, conflict resolution — is at [Skills reference → Scoping rules](../reference/skills.md#4-scoping-rules).
+The full set of rules — required vs. optional, bundled-required, materialisation strategy, conflict resolution — is at [Skills reference → Scoping rules](../reference/skills.md#5-scoping-rules).
 
 ---
 
@@ -340,7 +340,7 @@ Re-import from the parent folder that contains the skill directory (`/Users/me/s
 **Bundled skill keeps re-appearing after I delete it.**
 That's by design — `paperclip` and the other `paperclipai/paperclip/*` skills are re-imported on every list call. To suppress one, run a forked Paperclip build that doesn't ship it.
 
-For deeper debugging — wrong tool list, sync mode confusion, GitHub pin stuck on an old commit — walk the [full troubleshooting list](../reference/skills.md#8-troubleshooting-why-a-skill-isnt-loading).
+For deeper debugging — wrong tool list, sync mode confusion, GitHub pin stuck on an old commit — walk the [full troubleshooting list](../reference/skills.md#9-troubleshooting-why-a-skill-isnt-loading).
 
 ---
 


### PR DESCRIPTION
Fixes [PAP-17915](https://paperclip.ing/PAP/issues/PAP-17915). Follow-up to the crawlable-link-graph work in #105.

Nine in-article links carried a fragment the destination document does not define. The destination answers 200 and Google ignores fragments when indexing, so this is not an indexing defect — it is a reader-experience one: the link lands on the right page but at the top instead of the referenced section. They were invisible until #105 made the destinations reachable at all.

> **Based on #105, not `main`.** The warning list comes from the check that PR adds, so this branch is stacked on `pap-17913-crawlable-link-graph`. The diff below is this PR's single commit only. GitHub retargets the base to `main` automatically when #105 merges.

## Class A — anchor-convention mismatch (4 instances)

Authors wrote GitHub-flavoured anchors, which keep the double hyphen that a `:` or `/` in the heading leaves behind. `slugifyHeadingText` collapses `-+` to a single `-`.

| Author wrote | Site generates (now linked) |
| --- | --- |
| `#option-c--custom-script-no-paperclip-adapter` | `#option-c-custom-script-no-paperclip-adapter` |
| `#recommended-bundle-structure-agents--soul--heartbeat--tools` ×2 | `#recommended-bundle-structure-agents-soul-heartbeat-tools` |
| `#appendix--the-heartbeat-protocol-for-agent-developers` | `#appendix-the-heartbeat-protocol-for-agent-developers` |

**`slugifyHeadingText` is unchanged** (`git diff --name-only` touches no file under `site/`). Making the generator match GitHub's convention would fix these six author anchors and silently break every external deep link already pointing into these docs — the opposite of what the indexing work is trying to achieve.

## Class B — stale anchors (5 instances)

The Skills reference was renumbered since these were written:

| Was | Now |
| --- | --- |
| `#3-assigning-skills-to-agents` | `#4-assigning-skills-to-agents` |
| `#4-scoping-rules` | `#5-scoping-rules` |
| `#8-troubleshooting-why-a-skill-isnt-loading` ×2 | `#9-troubleshooting-why-a-skill-isnt-loading` |

**The glossary link needed more than an anchor swap.** The ticket says "the glossary has no per-letter anchors at all" — that is not accurate: the glossary *does* have per-letter headings (`## A` … `## U`, ids `a`…`u`). What it lacks is an **M** section, because it has no MCP term at all. So there was no correct anchor for `#m` to point at.

Dropping the fragment would clear the warning while leaving 8 of 9 links satisfying the actual acceptance criterion ("resolves to a heading id that exists in the destination document") and the ninth merely not-warning. The term is three lines, so the second commit adds it instead:

- `## M` between `## I` and `## O`, in alphabetical position
- `### MCP (Model Context Protocol)` in the existing per-term style, framed the way the docs frame it elsewhere — Paperclip does not speak MCP; the adapter launches the runtime and the runtime is what connects
- the link restored to its original "glossary entry" text, now pointing at `#mcp-model-context-protocol`

This is the one place the change goes past "edit the anchor". It is deliberate and it is what makes the ninth link actually resolve.

## Verification

No CI in this repo, so run locally on this branch:

```
$ npm run docs:test:crawlable-link-graph
Crawlable link graph verified: 1288 in-article links per build across 193 documents,
0 markdown hrefs, 193 allowed external markdown links, no redirect hops,
no redirects.json request (root and /paperclip-docs/ builds).

$ npm run docs:test:static-routes
Static route verification passed (5 representative routes +
/guides/welcome/this-route-does-not-exist/, root and /paperclip-docs/ builds).

$ npm run docs:test:asset-fingerprints
Asset fingerprint verification passed (bundle app.1a67afe85f24.js, 1 bundle, headers checked).

$ npm run docs:test:hierarchical-skills-nav
Hierarchical Skills nav verification passed.
```

**Zero warnings** — down from the 18 (9 links × root + `/paperclip-docs/` builds) reported before this change. The link count goes 1287 → 1288 because the new glossary term cross-links back to the how-to.

Beyond the suite, each fixed href was checked positively against the ids actually present in the built destination HTML — `href="…"` is present in the source page **and** the fragment matches a real `id=` in the destination — for all seven distinct links. And the landing behaviour was confirmed in a real headless Chromium against the built site: loading `/reference/skills/#9-troubleshooting-why-a-skill-isnt-loading` scrolls the heading to 128px from the top, just under the sticky header, and the new `/guides/welcome/glossary/#mcp-model-context-protocol` settles at the identical 128px.

<details>
<summary>One pre-existing site behaviour noticed while browser-testing (not from this PR)</summary>

Client-side *click-through* to an in-article fragment consistently under-scrolls by 2383px, while a direct URL load with the same fragment lands correctly. A pre-existing link with an already-correct fragment (`/guides/projects-workflow/routines/#variable-templates`) under-scrolls by the identical 2383px, so this affects every in-article fragment link equally and is not a regression from these edits. Filed separately.

</details>

## Known pre-existing failure, not from this PR

`npm run docs:test:skill-source-blocks` fails with `docs/reference/skills/optional/content/simplified-english.md: expected exactly one skill-source block, found 0`. Confirmed byte-identical on a clean `origin/main` worktree.

## Scope

Nine link fragments across five files, plus a three-line glossary term added so the ninth has something to resolve to. No changes to existing headings, no navigation changes, no `site/` changes, no other link's destination touched, no Google Search Console action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
