### PR TITLE
docs: render the simplified-english skill source block

### DIFF
--- a/docs/reference/skills/optional/content/simplified-english.md
+++ b/docs/reference/skills/optional/content/simplified-english.md
@@ -46,23 +46,25 @@ This is an **optional** catalog skill — opt-in (install when you need it). For
 
 ## Full skill definition
 
-### Skill frontmatter
+The block below is the complete, authoritative `SKILL.md` for this skill — the exact file an agent loads at runtime. Use the controls in the top-right of the block to copy it or download it as `SKILL.md`.
 
-- **name:** simplified-english
-- **description:** Write user-facing comments, plans, and documents in ASD-STE100 Simplified Technical English — short, unambiguous sentences with approved words and one meaning each — so readers understand them the first time.
-- **key:** paperclipai/optional/content/simplified-english
-- **recommendedForRoles:**
+````markdown skill-source
+---
+name: simplified-english
+description: Write user-facing comments, plans, and documents in ASD-STE100 Simplified Technical English — short, unambiguous sentences with approved words and one meaning each — so readers understand them the first time.
+key: paperclipai/optional/content/simplified-english
+recommendedForRoles:
   - engineer
   - product
   - writer
   - devrel
-- **tags:**
+tags:
   - writing
   - communication
   - clarity
   - style
+---
 
-### Skill instructions
 # Simplified English
 
 For user-facing comments, plans, and documents, write using only ASD-STE100 Simplified Technical English.
@@ -87,6 +89,7 @@ The approved words are the ASD-STE100 controlled vocabulary — the Dictionary i
 - "about" (not "regarding", "in relation to")
 - "help" (not "facilitate")
 - "use" (not "utilize", "employ")
+````
 
 ## See also
 


### PR DESCRIPTION
Fixes the last red check on `main`.

## What was wrong

`docs/reference/skills/optional/content/simplified-english.md` was left on the pre-#89 layout — parsed `### Skill frontmatter` bullets plus a `### Skill instructions` section — so it was the only per-skill page without an embedded `SKILL.md`. `docs:test:skill-source-blocks` has failed on it since release #95:

```
docs/reference/skills/optional/content/simplified-english.md:
  expected exactly one skill-source block, found 0
```

## The fix

Replaces both legacy sections with the authoritative `SKILL.md` in a single ` ```markdown skill-source ` block, matching every other per-skill page.

Source copied verbatim from `paperclipai/paperclip` at `9964b03`, path `packages/skills-catalog/catalog/optional/content/simplified-english/SKILL.md`. **No guidance changed** — the upstream file's content is identical to what the page already described in its parsed form, so this is purely a layout conversion.

## Bonus: duplicate H1

The old layout rendered two H1s — the page title, then the `SKILL.md`'s own `# Simplified English` under "Skill instructions". That's the same duplicate-H1 defect #87 fixed elsewhere, surviving on this one page.

```
BEFORE: h1=2  skill-download-blocks=0
AFTER:  h1=1  skill-download-blocks=1
```

## Verified

All five docs verifiers pass — the first fully green run:

```
Static route verification passed (5 representative routes + /guides/welcome/this-route-does-not-exist/, root and /paperclip-docs/ builds).
Asset fingerprint verification passed (bundle app.9b5b423f039c.js, 1 bundle, headers checked).
Hierarchical Skills nav verification passed.
Crawlable-link contract passed: 40886 internal links across 194 pages resolve in one hop, the server-rendered sidebar covers all 192 manifest routes, and sitemap dates are not uniform.
Skill source block verification passed (11 skill pages, 1 control page).
```

Note the verifier now covers **11** skill pages rather than 10 — this page previously fell out of the contract entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)