### PR TITLE
Release docs for paperclip v2026.824.1

### DIFF
--- a/.sync-state.json
+++ b/.sync-state.json
@@ -1,9 +1,9 @@
 {
   "branch_mode": "release",
-  "base_release_tag": "v2026.824.0",
-  "base_release_sha": "664052f8ea17030ac6085db9ff3880789e0bac3f",
-  "last_seen_parent_sha": "fa40a1b8d502ac19cfca2fcc5bbbdbf331410787",
-  "last_applied_manifest_hash": "7a14a90ac2b89d799b2f454fe307cfb5b35b7b12515d8b4eafb55966e9e92859",
-  "last_run_at": "2026-08-25T05:23:03Z",
+  "base_release_tag": "v2026.824.1",
+  "base_release_sha": "8e6edcdfa911151adba26be49a41cf5017b3aade",
+  "last_seen_parent_sha": "d785b19213a572bff9f92204dc7b8922217ef979",
+  "last_applied_manifest_hash": "8abb871cb9b9ee3c46ddb7343201091f21bd75e4e2d2470370310f674cba2161",
+  "last_run_at": "2026-08-27T08:00:58Z",
   "last_run_outcome": "applied"
 }

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,5 +1,5 @@
 ---
-paperclip_version: v2026.824.0
+paperclip_version: v2026.824.1
 seo_title: Documentation Changelog
 seo_description: What changed in these docs — pages added, rewritten, or expanded — with every documentation update. For product releases, see the Paperclip changelog.
 ---
@@ -13,6 +13,17 @@ The docs track Paperclip's [calendar-versioned](https://github.com/paperclipai/p
 ---
 
 <details class="accordion" open>
+<summary>Docs for v2026.824.1 <span class="accordion-meta">August 25, 2026</span></summary>
+<div class="accordion-body">
+
+**Updated pages**
+
+- [CLI Setup Commands](cli/setup-commands.md) — after `onboard` installs the background service, it now hands you off to the running instance: it waits for the port the service actually bound, prints the dashboard URL, and opens it in your browser. Headless runs print the URL, and `PAPERCLIP_NO_BROWSER=1` opts out of the browser launch.
+
+</div>
+</details>
+
+<details class="accordion">
 <summary>Docs for v2026.824.0 <span class="accordion-meta">August 24, 2026</span></summary>
 <div class="accordion-body">
 

--- a/docs/reference/cli/setup-commands.md
+++ b/docs/reference/cli/setup-commands.md
@@ -1,5 +1,5 @@
 ---
-paperclip_version: v2026.609.0
+paperclip_version: v2026.824.1
 seo_title: CLI Setup Commands
 seo_description: Stand up a Paperclip instance, repair a broken one, or change the settings the server runs on — the commands that touch install and launch.
 ---
@@ -97,6 +97,8 @@ The first prompt offers two paths:
 | `--run` | Start the server immediately after saving the config. |
 
 Near the end of the wizard, `onboard` offers to install Paperclip as a background service so it starts on login and keeps running after you close the terminal. `--install-service` installs it without asking; `--no-install-service` skips both the install and the suggestion. When the service is installed, onboarding does *not* also start a foreground server — the service is already running Paperclip for you. On a platform where service management is unavailable, `--install-service` warns and continues. See [Service](./service.md) for what gets installed and how to manage it.
+
+Once the service is running, onboarding hands you off to it instead of stopping at the terminal: it waits for the service to report the port it actually bound (a fallback port is used automatically if the configured one is busy), prints the dashboard URL, and — on an interactive terminal — opens it in your browser. Headless and non-interactive runs print the URL without launching a browser. Set `PAPERCLIP_NO_BROWSER=1` to keep onboarding from opening a browser even in an interactive terminal. If the service does not come up in time, onboarding says so and points you at `paperclipai service logs` rather than claiming success.
 
 > **Note:** If a valid config already exists, `onboard` preserves it unchanged, ensures the agent JWT secret and secrets key exist, and prints next-step commands. Use [`configure`](#paperclipai-configure) to change settings on an existing install rather than re-onboarding.
 

--- a/scripts/sync/check-drift.mjs
+++ b/scripts/sync/check-drift.mjs
@@ -263,6 +263,19 @@ function lineOfOffset(content, offset) {
   return line;
 }
 
+function frontmatterEnd(content) {
+  // If the file opens with a YAML frontmatter block (--- ... ---), return the
+  // character offset just past the closing delimiter; otherwise 0. Prose inside
+  // seo_title / seo_description regularly contains phrases like "the single
+  // paperclipai binary" or "wiring paperclipai into a script" that the CLI and
+  // parent-path scanners would otherwise misread as command invocations or file
+  // references. Skipping the frontmatter region (rather than stripping it) keeps
+  // the 1-based line numbers of real, body-text hits intact.
+  if (!content.startsWith("---")) return 0;
+  const m = /^---\r?\n[\s\S]*?\r?\n---\r?\n/.exec(content);
+  return m ? m[0].length : 0;
+}
+
 // --- Class 1: parent file paths --------------------------------------------
 
 const PARENT_PATH_RE = /\b((?:cli\/src|server\/src|skills\/paperclip|packages\/[a-z0-9-]+(?:\/[a-z0-9-]+)?)\/[A-Za-z0-9_./-]+\.(?:ts|mjs|js))\b/g;
@@ -272,9 +285,11 @@ function collectParentPaths(docFiles) {
   const refs = new Map();
   for (const file of docFiles) {
     const content = readFileSync(file, "utf8");
+    const fmEnd = frontmatterEnd(content);
     PARENT_PATH_RE.lastIndex = 0;
     let m;
     while ((m = PARENT_PATH_RE.exec(content))) {
+      if (m.index < fmEnd) continue; // skip seo_title / seo_description prose
       const p = m[1];
       const line = locate(content, p);
       if (!refs.has(p)) refs.set(p, { docs: [] });
@@ -301,9 +316,11 @@ function collectCliCommands(docFiles) {
   for (const file of docFiles) {
     if (!file.includes("/docs/reference/cli/")) continue;
     const content = readFileSync(file, "utf8");
+    const fmEnd = frontmatterEnd(content);
     CLI_INVOCATION_RE.lastIndex = 0;
     let m;
     while ((m = CLI_INVOCATION_RE.exec(content))) {
+      if (m.index < fmEnd) continue; // skip seo_title / seo_description prose
       const head = m[1];
       const sub = m[2];
       if (CLI_FALSE_POSITIVES.has(head)) continue;


### PR DESCRIPTION
Release docs sync for **paperclip v2026.824.1** (cumulative window `v2026.824.0 → v2026.824.1`, 4 commits / 12 files). This patch release repairs the onboarding background-service flow end to end.

## Change manifest

| Watcher | Parent files | Kind | Docs target |
|---|---|---|---|
| cli-commands | `cli/src/commands/onboard.ts`, `cli/src/onboard-service.ts` | modified | `docs/reference/cli/setup-commands.md` |

**`docs/reference/cli/setup-commands.md`** (`onboard` section) — once the background service is installed, onboarding now hands you off to the running instance: it waits for the port the service actually bound (fallback port if the configured one is busy), prints the dashboard URL, and opens it in your browser on interactive terminals. Headless runs print the URL; the new **`PAPERCLIP_NO_BROWSER=1`** opts out of the browser launch. If the service doesn't come up, onboarding points at `paperclipai service logs` instead of claiming success. `paperclip_version` bumped to `v2026.824.1`.

**`docs/reference/changelog.md`** — new `v2026.824.1` docs-changelog entry.

Not doc-worthy this window: `run.ts` runtime-info plumbing, the `paperclipai doctor` diagnostic-message refinements, and the test files — no new or now-wrong surface in our docs.

## Verification

- `docs:build` ✓ · `sync:check` ✓ · full `docs:test` (6/6) ✓
- **verify-edit** against `v2026.824.1`: **47 claims verified, 0 unverified, 0 suspicious**. `PAPERCLIP_NO_BROWSER` and `paperclipai service logs` both confirmed in parent code at the tag.
- **Tag-accuracy (Phase 5.7):** self-contained release — `nightly` carries no doc drafts (only `.sync-state.json` differs from `main`), so there are no post-tag leaks to quarantine.
- **Screenshots:** window touched only `cli/**`, no `ui/src/**` — nothing stale.

## ⚠ Drift

Investigated against `v2026.824.1`. The two previously high-confidence CLI findings (`paperclipai binary`, `paperclipai into`) were **scanner false positives** — the drift scanner was reading `paperclipai <word>` out of `seo_description` frontmatter prose. Fixed in this PR (`scripts/sync/check-drift.mjs` now skips the YAML frontmatter block); both disappear.

Remaining (5, medium, `Verify:` — **confirmed correct, no action needed**):

- `POST /api/companies/import/transfers` · `docs/reference/api/companies.md:433`
- `PUT /api/companies/import/transfers/{transferId}/parts/{partIndex}` · :434
- `GET /api/companies/import/transfers/{transferId}` · :435
- `POST /api/companies/import/transfers/{transferId}/preview` · :436
- `POST /api/companies/import/transfers/{transferId}/apply` · :437

These routes **exist** at `v2026.824.1` (`server/src/routes/companies.ts` lines 696/762/825/944/958), registered via the `COMPANY_IMPORT_TRANSFERS_ROUTE_PATH` constant from `@paperclipai/shared`. The scanner only matches string-literal paths, so constant/template-literal registration reads as a false negative — a known medium-tier limitation. The docs are accurate; nothing to change. (A follow-up could teach the resolver to follow cross-package path constants.)

## Checklist

- [x] Cumulative diff from last release tag
- [x] Edits verified against the release tag
- [x] Build + link + SEO + crawlable gates pass
- [x] Drift investigated; false positives fixed at the scanner, false negatives confirmed correct
- [x] Docs-changelog entry added
- [ ] After merge: tag `docs/v2026.824.1`, realign `nightly`, verify `docs.paperclip.ing` serves the release
