### PR TITLE
seo: publish sitemap lastmod dates from Cloudflare Pages builds

### DIFF
--- a/site/build-release.mjs
+++ b/site/build-release.mjs
@@ -651,22 +651,53 @@ async function pageMetadataForNav(nav, outDir, siteUrl, basePath) {
 // single commit, so `git log -1` reports that commit's date for *every* file.
 // The dates look valid and are uniformly wrong, which is worse than having
 // none: every sitemap resubmission then claims the whole site changed at once
-// and Google learns to discount the signal.
+// and Google learns to discount the signal. So: deepen the checkout if we can,
+// and fall back to publishing no dates at all if we can't.
 let trustworthyGitHistory = null;
+
+async function isShallowRepository() {
+  const { stdout } = await execFileAsync("git", ["rev-parse", "--is-shallow-repository"], {
+    cwd: repoRoot,
+  });
+  return stdout.trim() === "true";
+}
+
+// Cloudflare Pages builds from a depth-1 clone and its clone depth is not
+// configurable, so asking the caller for full history is not an option there.
+// Deepening the checkout in-place is: the build container keeps the remote it
+// cloned from, and this repo's history is small enough to fetch in seconds.
+const UNSHALLOW_TIMEOUT_MS = 90_000;
+async function deepenCheckout() {
+  try {
+    await execFileAsync("git", ["fetch", "--unshallow", "--quiet"], {
+      cwd: repoRoot,
+      timeout: UNSHALLOW_TIMEOUT_MS,
+    });
+    return !(await isShallowRepository());
+  } catch (error) {
+    // Print the reason: whether this fails is entirely down to whether the
+    // build environment kept usable fetch credentials, and the build log is
+    // the only place we get to find that out.
+    const detail = (error.stderr || error.message || "").trim().split("\n")[0];
+    console.warn(`Could not deepen the shallow checkout: ${detail}`);
+    return false;
+  }
+}
+
 async function hasTrustworthyGitHistory() {
   if (trustworthyGitHistory !== null) return trustworthyGitHistory;
   try {
-    const { stdout } = await execFileAsync("git", ["rev-parse", "--is-shallow-repository"], {
-      cwd: repoRoot,
-    });
-    const isShallow = stdout.trim() === "true";
-    if (isShallow) {
+    let usable = !(await isShallowRepository());
+    if (!usable) {
+      console.warn("Shallow git checkout detected: fetching full history for sitemap <lastmod>.");
+      usable = await deepenCheckout();
       console.warn(
-        "Shallow git checkout detected: omitting sitemap <lastmod>. "
-          + "Clone with full history (actions/checkout fetch-depth: 0) to publish real dates.",
+        usable
+          ? "Full history fetched: publishing real sitemap <lastmod> dates."
+          : "Still shallow: omitting sitemap <lastmod> rather than dating every page alike.",
       );
     }
-    trustworthyGitHistory = !isShallow;
+    trustworthyGitHistory = usable;
   } catch {
     trustworthyGitHistory = false;
   }


### PR DESCRIPTION
## The problem

`https://docs.paperclip.ing/sitemap.xml` contains **zero `<lastmod>` elements** — 192 pages plus the root, none dated. It has never shipped one.

The empty line after each `<loc>` is the tell: production *is* running the current template, it just has nothing to emit.

```xml
  <url>
    <loc>https://docs.paperclip.ing/guides/welcome/key-concepts/</loc>

  </url>
```

## Why

Dates come from per-file git history. The guard added in #113 suppresses them on a shallow checkout, and it is right to — with one commit, `git log -1` reports that commit's date for *every* file, so the sitemap would claim the whole site changed at once and Google would learn to discount the signal.

Cloudflare Pages builds from a depth-1 clone, and **its clone depth is not configurable from this repo**. `docs-checks.yml` sets `fetch-depth: 0` for exactly this reason, but that workflow only checks the build — Pages' Git integration is what deploys. So the guard fired on every production deploy since #113.

Reproduced locally:

| Build environment | `lastmod` entries |
|---|---|
| Full history | 193, real varied dates |
| `git clone --depth 1` | 0 — output byte-identical to production |

## The change

Try `git fetch --unshallow` (90s timeout) before giving up, and log which branch it took so the Cloudflare build log answers the question directly.

## Verification

| Scenario | Result |
|---|---|
| Shallow clone, fetchable remote | 1 commit → 257, **193 dates emitted** |
| Shallow clone, unreachable remote | logs the git error, omits dates, **exit 0** |
| Full clone (unchanged path) | unaffected |
| `npm run docs:test` (6 suites) + `npm run sync:test` (38 tests) | pass |

## What this PR cannot prove

The local test cloned from a `file://` remote, which can always fetch. **Whether Cloudflare's build container keeps usable credentials for the remote it cloned from is the entire open question**, and only a real deploy answers it — hence this PR and its preview.

- Works → preview `sitemap.xml` carries dates, build log says `Full history fetched`.
- Doesn't → build log says `Could not deepen the shallow checkout: <reason>`, sitemap is exactly what we ship today. No regression either way; fall back to deploying from Actions with `fetch-depth: 0`.

## Known, not fixed here

Even with full history, **190 of 193 pages date to `2026-08-25`** — 325c9eb rewrote frontmatter across all 192 pages that day. Truthful, but nearly signal-free, and it clears `dropUniformLastmod` only because 3 pages differ. It self-heals as pages get edited individually. Widening that guard to a percentage threshold would suppress dates again today, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)